### PR TITLE
Import basic bytecode linking code from browser-solidity

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,3 +104,15 @@ solc.loadRemoteVersion('latest', function(err, solcSnapshot) {
 	var output = solcSnapshot.compile("contract t { function g() {} }", 1);
 });
 ```
+
+### Linking bytecode
+
+When using libraries, the resulting bytecode will contain placeholders for the real addresses of the referenced libraries. These have to be updated, via a process called linking, before deploying the contract.
+
+The `linkBytecode` method provides a simple helper for linking:
+
+```javascript
+bytecode = solc.linkBytecode(bytecode, { 'MyLibrary': '0x123456...' });
+```
+
+Note: in future versions of Solidity a more sophisticated linker architecture will be introduced.  Once that changes, this method will still be usable for output created by old versions of Solidity.

--- a/wrapper.js
+++ b/wrapper.js
@@ -47,11 +47,29 @@ function setupMethods (soljson) {
     return JSON.parse(result);
   };
 
+  var linkBytecode = function (bytecode, libraries) {
+    for (var libraryName in libraries) {
+      var libLabel = '__' + libraryName + Array(39 - libraryName.length).join('_');
+
+      var hexAddress = libraries[libraryName];
+      // remove 0x prefix
+      hexAddress = hexAddress.slice(2);
+      hexAddress = Array(40 - hexAddress.length + 1).join('0') + hexAddress;
+
+      while (bytecode.indexOf(libLabel) >= 0) {
+        bytecode = bytecode.replace(libLabel, hexAddress);
+      }
+    }
+
+    return bytecode;
+  };
+
   var version = soljson.cwrap('version', 'string', []);
 
   return {
     version: version,
     compile: compile,
+    linkBytecode: linkBytecode,
     supportsMulti: compileJSONMulti !== null,
     supportsImportCallback: compileJSONCallback !== null,
     // Use the given version if available.

--- a/wrapper.js
+++ b/wrapper.js
@@ -49,7 +49,10 @@ function setupMethods (soljson) {
 
   var linkBytecode = function (bytecode, libraries) {
     for (var libraryName in libraries) {
-      var libLabel = '__' + libraryName + Array(39 - libraryName.length).join('_');
+      // truncate to 37 characters
+      var internalName = libraryName.slice(0, 36);
+      // prefix and suffix with __
+      var libLabel = '__' + internalName + Array(37 - internalName.length).join('_') + '__';
 
       var hexAddress = libraries[libraryName];
       // remove 0x prefix

--- a/wrapper.js
+++ b/wrapper.js
@@ -55,6 +55,9 @@ function setupMethods (soljson) {
       var libLabel = '__' + internalName + Array(37 - internalName.length).join('_') + '__';
 
       var hexAddress = libraries[libraryName];
+      if (hexAddress.slice(0, 2) !== '0x' || hexAddress.length > 42) {
+        throw new Error('Invalid address specified for ' + libraryName);
+      }
       // remove 0x prefix
       hexAddress = hexAddress.slice(2);
       hexAddress = Array(40 - hexAddress.length + 1).join('0') + hexAddress;


### PR DESCRIPTION
This is only the internal part of the linker, which replaces library references with addresses in a given bytecode. Code taken form browser-solidity. First step to implement #4.

The higher level method will need to support JSON input and perhaps handle multiple versions of the same library name.

