### PR TITLE
Introduce cli - solcjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,19 @@ To use the latest stable version of the Solidity compiler via Node.js you can in
 npm install solc
 ```
 
-And then use it like so:
+### Using on the command line
+
+If this package is installed globally (`npm install -g solc`), a commandline tool called `solcjs` will be available.
+
+To see all the supported features, execute:
+
+```bash
+solcjs --help
+```
+
+### Using in projects
+
+It can also be included and used in other projects:
 
 ```javascript
 var solc = require('solc');

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.3.5",
   "description": "Solidity compiler",
   "main": "index.js",
+  "bin": {
+    "solcjs": "solcjs"
+  },
   "scripts": {
     "lint": "semistandard",
     "prepublish": "./downloadCurrentVersion.js",
@@ -19,6 +22,7 @@
   ],
   "files": [
     "index.js",
+    "solcjs",
     "soljson.js",
     "wrapper.js"
   ],
@@ -30,7 +34,8 @@
   "homepage": "https://github.com/ethereum/solc-js#readme",
   "dependencies": {
     "memorystream": "^0.3.1",
-    "require-from-string": "^1.1.0"
+    "require-from-string": "^1.1.0",
+    "yargs": "^4.7.1"
   },
   "devDependencies": {
     "semistandard": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
   },
   "devDependencies": {
     "semistandard": "^8.0.0",
-    "tape": "^4.5.1"
+    "tape": "^4.5.1",
+    "tape-spawn": "^1.4.2"
   },
   "semistandard": {
     "ignore": [

--- a/solcjs
+++ b/solcjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 var fs = require('fs');
+var path = require('path');
 var solc = require('./index.js');
 // FIXME: remove annoying exception catcher of Emscripten
 //        see https://github.com/chriseth/browser-solidity/issues/167
@@ -20,6 +21,11 @@ var yargs = require('yargs')
     describe: 'Binary of the contracts in hex.',
     type: 'boolean'
   })
+  .option('destination', {
+    alias: 'D',
+    describe: 'Output directory for the contracts.',
+    type: 'string'
+  })
   .global([ 'version', 'optimize' ])
   .version()
   .showHelpOnFail(false, 'Specify --help for available options')
@@ -28,6 +34,7 @@ var yargs = require('yargs')
 
 var argv = yargs.argv;
 var files = argv._;
+var destination = argv.destination || '.'
 
 function abort (msg) {
   console.log(msg || 'Error occured');
@@ -47,5 +54,5 @@ for (var i = 0; i < files.length; i++) {
 var output = solc.compile({ sources: sources }, argv.optimize ? 1 : 0);
 
 for (var contractName in output.contracts) {
-  fs.writeFileSync(contractName + '.bin', output.contracts[contractName].bytecode);
+  fs.writeFileSync(path.join(destination, contractName + '.bin'), output.contracts[contractName].bytecode);
 }

--- a/solcjs
+++ b/solcjs
@@ -21,8 +21,8 @@ var yargs = require('yargs')
     describe: 'Binary of the contracts in hex.',
     type: 'boolean'
   })
-  .option('destination', {
-    alias: 'D',
+  .option('output-dir', {
+    alias: 'o',
     describe: 'Output directory for the contracts.',
     type: 'string'
   })
@@ -34,7 +34,7 @@ var yargs = require('yargs')
 
 var argv = yargs.argv;
 var files = argv._;
-var destination = argv.destination || '.'
+var destination = argv['output-dir'] || '.'
 
 function abort (msg) {
   console.log(msg || 'Error occured');

--- a/solcjs
+++ b/solcjs
@@ -21,6 +21,10 @@ var yargs = require('yargs')
     describe: 'Binary of the contracts in hex.',
     type: 'boolean'
   })
+  .option('abi', {
+    describe: 'ABI of the contracts.',
+    type: 'boolean'
+  })
   .option('output-dir', {
     alias: 'o',
     describe: 'Output directory for the contracts.',
@@ -41,7 +45,7 @@ function abort (msg) {
   process.exit(1);
 }
 
-if (!argv.bin) {
+if (!(argv.bin || argv.abi)) {
   abort('Invalid option selected');
 }
 
@@ -58,5 +62,11 @@ for (var i = 0; i < files.length; i++) {
 var output = solc.compile({ sources: sources }, argv.optimize ? 1 : 0);
 
 for (var contractName in output.contracts) {
-  fs.writeFileSync(path.join(destination, contractName + '.bin'), output.contracts[contractName].bytecode);
+  if (argv.bin) {
+    fs.writeFileSync(path.join(destination, contractName + '.bin'), output.contracts[contractName].bytecode);
+  }
+
+  if (argv.abi) {
+    fs.writeFileSync(path.join(destination, contractName + '.abi'), output.contracts[contractName].interface);
+  }
 }

--- a/solcjs
+++ b/solcjs
@@ -48,7 +48,11 @@ if (!argv.bin) {
 var sources = {};
 
 for (var i = 0; i < files.length; i++) {
-  sources[ files[i] ] = fs.readFileSync(files[i]).toString();
+  try {
+    sources[ files[i] ] = fs.readFileSync(files[i]).toString();
+  } catch (e) {
+    abort(`Error reading ${files[i]}: ${e}`);
+  }
 }
 
 var output = solc.compile({ sources: sources }, argv.optimize ? 1 : 0);

--- a/solcjs
+++ b/solcjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+
+var fs = require('fs');
+var solc = require('./index.js');
+// FIXME: remove annoying exception catcher of Emscripten
+//        see https://github.com/chriseth/browser-solidity/issues/167
+process.removeAllListeners('uncaughtException');
+
+var yargs = require('yargs')
+  .usage('Usage: $0 [options] [input_file...]')
+  .option('version', {
+    describe: 'Show version and exit.',
+    type: 'boolean'
+  })
+  .option('optimize', {
+    describe: 'Enable bytecode optimizer.',
+    type: 'boolean'
+  })
+  .option('bin', {
+    describe: 'Binary of the contracts in hex.',
+    type: 'boolean'
+  })
+  .global([ 'version', 'optimize' ])
+  .version()
+  .showHelpOnFail(false, 'Specify --help for available options')
+  .help()
+  .demand(1, 'Must provide a file');
+
+var argv = yargs.argv;
+var files = argv._;
+
+function abort (msg) {
+  console.log(msg || 'Error occured');
+  process.exit(1);
+}
+
+if (!argv.bin) {
+  abort('Invalid option selected');
+}
+
+var sources = {};
+
+for (var i = 0; i < files.length; i++) {
+  sources[ files[i] ] = fs.readFileSync(files[i]).toString();
+}
+
+var output = solc.compile({ sources: sources }, argv.optimize ? 1 : 0);
+
+for (var contractName in output.contracts) {
+  fs.writeFileSync(contractName + '.bin', output.contracts[contractName].bytecode);
+}

--- a/solcjs
+++ b/solcjs
@@ -59,7 +59,7 @@ for (var i = 0; i < files.length; i++) {
   try {
     sources[ files[i] ] = fs.readFileSync(files[i]).toString();
   } catch (e) {
-    abort(`Error reading ${files[i]}: ${e}`);
+    abort('Error reading ' + files[i] + ': ' + e);
   }
 }
 

--- a/solcjs
+++ b/solcjs
@@ -25,6 +25,10 @@ var yargs = require('yargs')
     describe: 'ABI of the contracts.',
     type: 'boolean'
   })
+  .option('interface', {
+    describe: 'Solidity Interface of the contracts.',
+    type: 'boolean'
+  })
   .option('output-dir', {
     alias: 'o',
     describe: 'Output directory for the contracts.',
@@ -45,7 +49,7 @@ function abort (msg) {
   process.exit(1);
 }
 
-if (!(argv.bin || argv.abi)) {
+if (!(argv.bin || argv.abi || argv.interface)) {
   abort('Invalid option selected');
 }
 
@@ -68,5 +72,9 @@ for (var contractName in output.contracts) {
 
   if (argv.abi) {
     fs.writeFileSync(path.join(destination, contractName + '.abi'), output.contracts[contractName].interface);
+  }
+
+  if (argv.interface) {
+    fs.writeFileSync(path.join(destination, contractName + '_interface.sol'), output.contracts[contractName].solidity_interface);
   }
 }

--- a/test/cli.js
+++ b/test/cli.js
@@ -28,4 +28,10 @@ tape('CLI', function (t) {
     spt.succeeds();
     spt.end();
   });
+
+  t.test('invalid file specified', function (st) {
+    var spt = spawn(st, './solcjs --bin test/fileNotFound.sol');
+    spt.stdout.match(/^Error reading /);
+    spt.end();
+  });
 });

--- a/test/cli.js
+++ b/test/cli.js
@@ -42,4 +42,20 @@ tape('CLI', function (t) {
     spt.succeeds();
     spt.end();
   });
+
+  t.test('--interface', function (st) {
+    var spt = spawn(st, './solcjs --interface test/DAO/Token.sol');
+    spt.stderr.empty();
+    spt.stdout.empty();
+    spt.succeeds();
+    spt.end();
+  });
+
+  t.test('--bin --abi --interface', function (st) {
+    var spt = spawn(st, './solcjs --bin --abi --interface test/DAO/Token.sol');
+    spt.stderr.empty();
+    spt.stdout.empty();
+    spt.succeeds();
+    spt.end();
+  });
 });

--- a/test/cli.js
+++ b/test/cli.js
@@ -1,0 +1,31 @@
+const tape = require('tape');
+const spawn = require('tape-spawn');
+const pkg = require('../package.json');
+
+tape('CLI', function (t) {
+  t.test('--version', function (st) {
+    var spt = spawn(st, './solcjs --version');
+    spt.stdout.match(pkg.version + '\n');
+    spt.end();
+  });
+
+  t.test('no parameters', function (st) {
+    var spt = spawn(st, './solcjs');
+    spt.stderr.match(/^Must provide a file/);
+    spt.end();
+  });
+
+  t.test('no mode specified', function (st) {
+    var spt = spawn(st, './solcjs test/DAO/Token.sol');
+    spt.stdout.match(/^Invalid option selected/);
+    spt.end();
+  });
+
+  t.test('--bin', function (st) {
+    var spt = spawn(st, './solcjs --bin test/DAO/Token.sol');
+    spt.stderr.empty();
+    spt.stdout.empty();
+    spt.succeeds();
+    spt.end();
+  });
+});

--- a/test/cli.js
+++ b/test/cli.js
@@ -34,4 +34,12 @@ tape('CLI', function (t) {
     spt.stdout.match(/^Error reading /);
     spt.end();
   });
+
+  t.test('--abi', function (st) {
+    var spt = spawn(st, './solcjs --abi test/DAO/Token.sol');
+    spt.stderr.empty();
+    spt.stdout.empty();
+    spt.succeeds();
+    spt.end();
+  });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -1,2 +1,3 @@
 require('./package.js');
+require('./cli.js');
 require('./determinism.js');


### PR DESCRIPTION
Moving the compiler part of my old tool https://github.com/axic/ethereumjs-codesim.

Would it make sense mirroring the CLI of `solc` or should we diverge?

Note: we cannot 100% mirror as many features are lacking (as of today) in soljson.

It is very basic at the moment, only supports `--bin`. Most of the features (AST, ABI, interface) can be supported.