### PR TITLE
Implement JSON I/O wrapper for older compilers

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ used in combination with an Ethereum client via the `eth.compile.solidity()` RPC
 
 ### Usage in Projects
 
+#### From early versions
+
 It can also be included and used in other projects:
 
 ```javascript
@@ -41,6 +43,8 @@ for (var contractName in output.contracts) {
 	console.log(contractName + '; ' + JSON.parse(output.contracts[contractName].interface));
 }
 ```
+
+#### From version 0.1.6
 
 Starting from version 0.1.6, multiple files are supported with automatic import resolution by the compiler as follows:
 
@@ -56,6 +60,8 @@ for (var contractName in output.contracts)
 ```
 
 Note that all input files that are imported have to be supplied, the compiler will not load any additional files on its own.
+
+#### From version 0.2.1
 
 Starting from version 0.2.1, a callback is supported to resolve missing imports as follows:
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ for (var contractName in output.contracts)
 
 The `compile()` method always returns an object, which can contain `errors`, `sources` and `contracts` fields. `errors` is a list of error mesages.
 
+#### From version 0.4.11
+
+Starting from version 0.4.11 there is a new entry point named `compileStandardWrapper()` which supports Solidity's [standard JSON input and output](https://solidity.readthedocs.io/en/develop/using-the-compiler.html#compiler-input-and-output-json-description). It also maps old compiler output to it.
+
 **Note:**
 If you are using Electron, `nodeIntegration` is on for `BrowserWindow` by default. If it is on, Electron will provide a `require` method which will not behave as expected and this may cause calls, such as `require('solc')`, to fail.
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "index.js",
     "solcjs",
     "soljson.js",
+    "translate.js",
     "wrapper.js"
   ],
   "author": "chriseth",

--- a/test/package.js
+++ b/test/package.js
@@ -107,6 +107,32 @@ tape('Compilation', function (t) {
     st.ok(bytecodeExists(output, 'lib.sol', 'L'));
     st.end();
   });
+  t.test('compiling standard JSON (using wrapper)', function (st) {
+    var input = {
+      'language': 'Solidity',
+      'sources': {
+        'lib.sol': {
+          'content': 'library L { function f() returns (uint) { return 7; } }'
+        },
+        'cont.sol': {
+          'content': 'import "lib.sol"; contract x { function g() { L.f(); } }'
+        }
+      }
+    };
+
+    function bytecodeExists (output, fileName, contractName) {
+      try {
+        return output.contracts[fileName][contractName]['evm']['bytecode']['object'].length > 0;
+      } catch (e) {
+        return false;
+      }
+    }
+
+    var output = solc.compileStandardWrapper(input);
+    st.ok(bytecodeExists(output, 'cont.sol', 'x'));
+    st.ok(bytecodeExists(output, 'lib.sol', 'L'));
+    st.end();
+  });
 });
 tape('Loading Legacy Versions', function (t) {
   t.test('loading remote version - development snapshot', function (st) {

--- a/test/package.js
+++ b/test/package.js
@@ -128,7 +128,7 @@ tape('Compilation', function (t) {
       }
     }
 
-    var output = solc.compileStandardWrapper(input);
+    var output = JSON.parse(solc.compileStandardWrapper(JSON.stringify(input)));
     st.ok(bytecodeExists(output, 'cont.sol', 'x'));
     st.ok(bytecodeExists(output, 'lib.sol', 'L'));
     st.end();

--- a/translate.js
+++ b/translate.js
@@ -13,7 +13,50 @@ function translateJsonCompiler (output) {
     });
   }
 
-  // FIXME: translate actual output too
+  ret['contracts'] = {};
+  for (var contract in output['contracts']) {
+    // Split name first, can be `contract`, `:contract` or `filename:contract`
+    var tmp = contract.match(/^([^:]*):?([^:]+)$/);
+    var fileName, contractName;
+    if (tmp.length === 3) {
+      fileName = tmp[1];
+      contractName = tmp[2];
+    } else if (tmp.length === 2) {
+      fileName = '';
+      contractName = tmp[1];
+    } else {
+      // Force abort
+      return null;
+    }
+
+    var contractInput = output['contracts'][contract];
+    var contractOutput = {
+      'abi': contractInput['interface'],
+      'metadata': contractInput['metadata'],
+      'evm': {
+        'legacyAssembly': contractInput['assembly'],
+        'bytecode': {
+          'object': contractInput['bytecode'],
+          'opcodes': contractInput['opcodes'],
+          'sourceMap': contractInput['srcmap']
+        },
+        'deployedBytecode': {
+          'object': contractInput['runtimeBytecode'],
+          'sourceMap': contractInput['srcmapRuntime']
+        },
+        // FIXME
+        'methodIdentifiers': contractInput['methodIdentifiers'],
+        // FIXME translate
+        'gasEstimates': contractInput['gasEstimates']
+      }
+    };
+
+    if (!ret['contracts'][fileName]) {
+      ret['contracts'][fileName] = {};
+    }
+
+    ret['contracts'][fileName][contractName] = contractOutput;
+  }
 
   return ret;
 }

--- a/translate.js
+++ b/translate.js
@@ -21,10 +21,17 @@ function translateErrors (ret, errors) {
 }
 
 function translateGasEstimates (gasEstimates) {
+  if (gasEstimates === null) {
+    return 'infinite'
+  }
+
+  if (typeof gasEstimates === 'number') {
+    return gasEstimates.toString()
+  }
+
   var gasEstimatesTranslated = {}
   for (var func in gasEstimates) {
-    var estimate = gasEstimates[func]
-    gasEstimatesTranslated[func] = estimate !== null ? estimate.toString() : 'infinite'
+    gasEstimatesTranslated[func] = translateGasEstimates(gasEstimates[func])
   }
   return gasEstimatesTranslated
 }
@@ -71,8 +78,8 @@ function translateJsonCompilerOutput (output) {
         'methodIdentifiers': contractInput['functionHashes'],
         'gasEstimates': {
           'creation': {
-            'codeDepositCost': gasEstimates['creation'][1] !== null ? gasEstimates['creation'][1].toString() : 'infinite',
-            'executionCost': gasEstimates['creation'][0] !== null ? gasEstimates['creation'][0].toString() : 'infinite'
+            'codeDepositCost': translateGasEstimates(gasEstimates['creation'][1]),
+            'executionCost': translateGasEstimates(gasEstimates['creation'][0])
           },
           'internal': translateGasEstimates(gasEstimates['internal']),
           'external': translateGasEstimates(gasEstimates['external'])

--- a/translate.js
+++ b/translate.js
@@ -83,6 +83,19 @@ function translateJsonCompilerOutput (output) {
     translateErrors(ret['errors'], output['formal']['errors']);
   }
 
+  var sourceMap = {}
+  for (var sourceId in output['sourceList']) {
+    sourceMap[output['sourceList'][sourceId]] = sourceId;
+  }
+
+  ret['sources'] = {}
+  for (var source in output['sources']) {
+    ret['sources'][source] = {
+      id: sourceMap[source],
+      legacyAST: output['sources'][source]
+    }
+  }
+
   return ret;
 }
 

--- a/translate.js
+++ b/translate.js
@@ -62,7 +62,7 @@ function translateJsonCompilerOutput (output) {
     var gasEstimates = contractInput['gasEstimates'];
 
     var contractOutput = {
-      'abi': contractInput['interface'],
+      'abi': JSON.parse(contractInput['interface']),
       'metadata': contractInput['metadata'],
       'evm': {
         'legacyAssembly': contractInput['assembly'],

--- a/translate.js
+++ b/translate.js
@@ -11,7 +11,7 @@ function translateErrors (ret, errors) {
   }
 }
 
-function translateJsonCompiler (output) {
+function translateJsonCompilerOutput (output) {
   var ret = {};
 
   ret['errors'] = [];
@@ -71,5 +71,5 @@ function translateJsonCompiler (output) {
 }
 
 module.exports = {
-  translateJsonCompiler: translateJsonCompiler
+  translateJsonCompilerOutput: translateJsonCompilerOutput
 };

--- a/translate.js
+++ b/translate.js
@@ -1,14 +1,14 @@
 function translateErrors (ret, errors) {
   for (var error in errors) {
-    var type = 'error'
-    var extractType = /^(.*):(\d+):(\d+):(.*):/
-    extractType = extractType.exec(errors[error])
+    var type = 'error';
+    var extractType = /^(.*):(\d+):(\d+):(.*):/;
+    extractType = extractType.exec(errors[error]);
     if (extractType) {
-      type = extractType[4].trim()
+      type = extractType[4].trim();
     } else if (errors[error].indexOf(': Warning:')) {
-      type = 'Warning'
+      type = 'Warning';
     } else if (errors[error].indexOf(': Error:')) {
-      type = 'Error'
+      type = 'Error';
     }
     ret.push({
       type: type,
@@ -22,18 +22,18 @@ function translateErrors (ret, errors) {
 
 function translateGasEstimates (gasEstimates) {
   if (gasEstimates === null) {
-    return 'infinite'
+    return 'infinite';
   }
 
   if (typeof gasEstimates === 'number') {
-    return gasEstimates.toString()
+    return gasEstimates.toString();
   }
 
-  var gasEstimatesTranslated = {}
+  var gasEstimatesTranslated = {};
   for (var func in gasEstimates) {
-    gasEstimatesTranslated[func] = translateGasEstimates(gasEstimates[func])
+    gasEstimatesTranslated[func] = translateGasEstimates(gasEstimates[func]);
   }
-  return gasEstimatesTranslated
+  return gasEstimatesTranslated;
 }
 
 function translateJsonCompilerOutput (output) {
@@ -94,17 +94,17 @@ function translateJsonCompilerOutput (output) {
     ret['contracts'][fileName][contractName] = contractOutput;
   }
 
-  var sourceMap = {}
+  var sourceMap = {};
   for (var sourceId in output['sourceList']) {
     sourceMap[output['sourceList'][sourceId]] = sourceId;
   }
 
-  ret['sources'] = {}
+  ret['sources'] = {};
   for (var source in output['sources']) {
     ret['sources'][source] = {
       id: sourceMap[source],
       legacyAST: output['sources'][source]
-    }
+    };
   }
 
   return ret;

--- a/translate.js
+++ b/translate.js
@@ -11,6 +11,15 @@ function translateErrors (ret, errors) {
   }
 }
 
+function translateGasEstimates (gasEstimates) {
+  var gasEstimatesTranslated = {}
+  for (var func in gasEstimates) {
+    var estimate = gasEstimates[func]
+    gasEstimatesTranslated[func] = estimate !== null ? estimate.toString() : 'infinite'
+  }
+  return gasEstimatesTranslated
+}
+
 function translateJsonCompilerOutput (output) {
   var ret = {};
 
@@ -33,6 +42,9 @@ function translateJsonCompilerOutput (output) {
     var contractName = tmp[3];
 
     var contractInput = output['contracts'][contract];
+
+    var gasEstimates = contractInput['gasEstimates'];
+
     var contractOutput = {
       'abi': contractInput['interface'],
       'metadata': contractInput['metadata'],
@@ -48,6 +60,14 @@ function translateJsonCompilerOutput (output) {
           'sourceMap': contractInput['srcmapRuntime']
         },
         'methodIdentifiers': contractInput['functionHashes'],
+        'gasEstimates': {
+          'creation': {
+            'codeDepositCost': gasEstimates['creation'][1] !== null ? gasEstimates['creation'][1].toString() : 'infinite',
+            'executionCost': gasEstimates['creation'][0] !== null ? gasEstimates['creation'][0].toString() : 'infinite'
+          },
+          'internal': translateGasEstimates(gasEstimates['internal']),
+          'external': translateGasEstimates(gasEstimates['external'])
+        }
       }
     };
 

--- a/translate.js
+++ b/translate.js
@@ -94,11 +94,6 @@ function translateJsonCompilerOutput (output) {
     ret['contracts'][fileName][contractName] = contractOutput;
   }
 
-  if (output['formal']) {
-    ret['why3'] = output['formal']['why3'];
-    translateErrors(ret['errors'], output['formal']['errors']);
-  }
-
   var sourceMap = {}
   for (var sourceId in output['sourceList']) {
     sourceMap[output['sourceList'][sourceId]] = sourceId;

--- a/translate.js
+++ b/translate.js
@@ -58,6 +58,11 @@ function translateJsonCompiler (output) {
     ret['contracts'][fileName][contractName] = contractOutput;
   }
 
+  if (output['formal']) {
+    ret['why3'] = output['formal']['why3'];
+    // FIXME: map errors to the above list
+  }
+
   return ret;
 }
 

--- a/translate.js
+++ b/translate.js
@@ -1,10 +1,19 @@
 function translateErrors (ret, errors) {
   for (var error in errors) {
-    // FIXME: parse warnings here
+    var type = 'error'
+    var extractType = /^(.*):(\d+):(\d+):(.*):/
+    extractType = extractType.exec(errors[error])
+    if (extractType) {
+      type = extractType[4].trim().toLowerCase()
+    } else if (errors[error].toLowerCase().indexOf(': warning:')) {
+      type = 'warning'
+    } else if (errors[error].toLowerCase().indexOf(': error:')) {
+      type = 'error'
+    }
     ret.push({
       type: 'Error',
       component: 'general',
-      severity: 'error',
+      severity: type,
       message: errors[error],
       formattedMessage: errors[error]
     });

--- a/translate.js
+++ b/translate.js
@@ -4,16 +4,16 @@ function translateErrors (ret, errors) {
     var extractType = /^(.*):(\d+):(\d+):(.*):/
     extractType = extractType.exec(errors[error])
     if (extractType) {
-      type = extractType[4].trim().toLowerCase()
-    } else if (errors[error].toLowerCase().indexOf(': warning:')) {
-      type = 'warning'
-    } else if (errors[error].toLowerCase().indexOf(': error:')) {
-      type = 'error'
+      type = extractType[4].trim()
+    } else if (errors[error].indexOf(': Warning:')) {
+      type = 'Warning'
+    } else if (errors[error].indexOf(': Error:')) {
+      type = 'Error'
     }
     ret.push({
-      type: 'Error',
+      type: type,
       component: 'general',
-      severity: type,
+      severity: (type === 'Warning') ? 'warning' : 'error',
       message: errors[error],
       formattedMessage: errors[error]
     });

--- a/translate.js
+++ b/translate.js
@@ -1,17 +1,21 @@
+function translateErrors (ret, errors) {
+  for (var error in errors) {
+    // FIXME: parse warnings here
+    ret.push({
+      type: 'Error',
+      component: 'general',
+      severity: 'error',
+      message: errors[error],
+      formattedMessage: errors[error]
+    });
+  }
+}
+
 function translateJsonCompiler (output) {
   var ret = {};
 
   ret['errors'] = [];
-  for (var error in output['errors']) {
-    // FIXME: parse warnings here
-    ret['errors'].push({
-      type: 'Error',
-      component: 'general',
-      severity: 'error',
-      message: output['errors'][error],
-      formattedMessage: output['errors'][error]
-    });
-  }
+  translateErrors(ret['errors'], output['errors']);
 
   ret['contracts'] = {};
   for (var contract in output['contracts']) {
@@ -60,7 +64,7 @@ function translateJsonCompiler (output) {
 
   if (output['formal']) {
     ret['why3'] = output['formal']['why3'];
-    // FIXME: map errors to the above list
+    translateErrors(ret['errors'], output['formal']['errors']);
   }
 
   return ret;

--- a/translate.js
+++ b/translate.js
@@ -20,18 +20,17 @@ function translateJsonCompilerOutput (output) {
   ret['contracts'] = {};
   for (var contract in output['contracts']) {
     // Split name first, can be `contract`, `:contract` or `filename:contract`
-    var tmp = contract.match(/^([^:]*):?([^:]+)$/);
-    var fileName, contractName;
-    if (tmp.length === 3) {
-      fileName = tmp[1];
-      contractName = tmp[2];
-    } else if (tmp.length === 2) {
-      fileName = '';
-      contractName = tmp[1];
-    } else {
+    var tmp = contract.match(/^(([^:]*):)?([^:]+)$/);
+    if (tmp.length !== 4) {
       // Force abort
       return null;
     }
+    var fileName = tmp[2];
+    if (fileName === undefined) {
+      // this is the case of `contract`
+      fileName = '';
+    }
+    var contractName = tmp[3];
 
     var contractInput = output['contracts'][contract];
     var contractOutput = {

--- a/translate.js
+++ b/translate.js
@@ -47,10 +47,7 @@ function translateJsonCompilerOutput (output) {
           'object': contractInput['runtimeBytecode'],
           'sourceMap': contractInput['srcmapRuntime']
         },
-        // FIXME
-        'methodIdentifiers': contractInput['methodIdentifiers'],
-        // FIXME translate
-        'gasEstimates': contractInput['gasEstimates']
+        'methodIdentifiers': contractInput['functionHashes'],
       }
     };
 

--- a/translate.js
+++ b/translate.js
@@ -1,0 +1,23 @@
+function translateJsonCompiler (output) {
+  var ret = {};
+
+  ret['errors'] = [];
+  for (var error in output['errors']) {
+    // FIXME: parse warnings here
+    ret['errors'].push({
+      type: 'Error',
+      component: 'general',
+      severity: 'error',
+      message: output['errors'][error],
+      formattedMessage: output['errors'][error]
+    });
+  }
+
+  // FIXME: translate actual output too
+
+  return ret;
+}
+
+module.exports = {
+  translateJsonCompiler: translateJsonCompiler
+};

--- a/wrapper.js
+++ b/wrapper.js
@@ -78,11 +78,11 @@ function setupMethods (soljson) {
   // Expects a Standard JSON I/O but supports old compilers
   var compileStandardWrapper = function (input, readCallback) {
     if (compileStandard !== null) {
-      return JSON.parse(compileStandard(JSON.stringify(input), readCallback));
+      return compileStandard(input, readCallback);
     }
 
     function formatFatalError (message) {
-      return {
+      return JSON.stringify({
         errors: [
           {
             'type': 'SOLCError',
@@ -92,8 +92,10 @@ function setupMethods (soljson) {
             'formattedMessage': 'Error' + message
           }
         ]
-      };
+      });
     }
+
+    input = JSON.parse(input);
 
     if (input['language'] !== 'Solidity') {
       return formatFatalError('Only Solidity sources are supported');
@@ -130,7 +132,7 @@ function setupMethods (soljson) {
       if (output == null) {
         return formatFatalError('Failed to process output');
       }
-      return output;
+      return JSON.stringify(output);
     }
 
     var sources = translateSources(input);

--- a/wrapper.js
+++ b/wrapper.js
@@ -126,7 +126,7 @@ function setupMethods (soljson) {
     }
 
     function translateOutput (output) {
-      output = translate.translateJsonCompiler(JSON.parse(output));
+      output = translate.translateJsonCompilerOutput(JSON.parse(output));
       if (output == null) {
         return formatFatalError('Failed to process output');
       }

--- a/wrapper.js
+++ b/wrapper.js
@@ -95,6 +95,10 @@ function setupMethods (soljson) {
       };
     }
 
+    if (input['language'] !== 'Solidity') {
+      return formatFatalError('Only Solidity sources are supported');
+    }
+
     if (input['sources'] == null) {
       return formatFatalError('No input specified');
     }

--- a/wrapper.js
+++ b/wrapper.js
@@ -1,3 +1,4 @@
+var translate = require('./translate.js');
 var requireFromString = require('require-from-string');
 var https = require('https');
 var MemoryStream = require('memorystream');
@@ -121,8 +122,10 @@ function setupMethods (soljson) {
     }
 
     function translateOutput (output) {
-      output = JSON.parse(output);
-      // FIXME: translate jsonCompiler output to Standard I/O
+      output = translate.translateJsonCompiler(JSON.parse(output));
+      if (output == null) {
+        return formatFatalError('Failed to process output');
+      }
       return output;
     }
 


### PR DESCRIPTION
Depends on #93. Deprecates #33.

Todo:
- [x] Support AST
- [x] Translate methodIdentifiers
- [x] Translate gasEstimates
- [x] Fix `filename:contractname` parsing
- [x] Parse warnings vs. errors