### PR TITLE
Replace ':' (and `.` `/`) with '-' in output filenames for solcjs

### DIFF
--- a/solcjs
+++ b/solcjs
@@ -37,8 +37,8 @@ var yargs = require('yargs')
     describe: 'Output directory for the contracts.',
     type: 'string'
   })
-  .option('replace-colon', {
-    describe: 'Replace colon char with minus in output file names,',
+  .option('friendly-filenames', {
+    describe: 'Replace illegal filename chars with underscore in output file names,',
     type: 'boolean'
   })
   .global([ 'version', 'optimize' ])
@@ -111,16 +111,16 @@ function writeFile (file, content) {
 
 for (var contractName in output.contracts) {
   var contractFileName = contractName;
-  if (argv.replaceColon) {
-      contractFileName = contractFileName.replace(':', '-');
+  if (argv.friendlyFilenames) {
+      contractFileName = contractFileName.replace(/[:./]/g,'');
   }
 
   if (argv.bin) {
-    writeFile(contractName + '.bin', output.contracts[contractName].bytecode);
+    writeFile(contractFileName + '.bin', output.contracts[contractName].bytecode);
   }
 
   if (argv.abi) {
-    writeFile(contractName + '.abi', output.contracts[contractName].interface);
+    writeFile(contractFileName + '.abi', output.contracts[contractName].interface);
   }
 }
 

--- a/solcjs
+++ b/solcjs
@@ -37,6 +37,10 @@ var yargs = require('yargs')
     describe: 'Output directory for the contracts.',
     type: 'string'
   })
+  .option('replace-colon', {
+    describe: 'Replace colon char with minus in output file names,',
+    type: 'boolean'
+  })
   .global([ 'version', 'optimize' ])
   .version(function() { return solc.version(); })
   .showHelpOnFail(false, 'Specify --help for available options')
@@ -106,6 +110,11 @@ function writeFile (file, content) {
 }
 
 for (var contractName in output.contracts) {
+  var contractFileName = contractName;
+  if (argv.replaceColon) {
+      contractFileName = contractFileName.replace(':', '-');
+  }
+
   if (argv.bin) {
     writeFile(contractName + '.bin', output.contracts[contractName].bytecode);
   }

--- a/solcjs
+++ b/solcjs
@@ -37,10 +37,6 @@ var yargs = require('yargs')
     describe: 'Output directory for the contracts.',
     type: 'string'
   })
-  .option('friendly-filenames', {
-    describe: 'Replace illegal filename chars with underscore in output file names,',
-    type: 'boolean'
-  })
   .global([ 'version', 'optimize' ])
   .version(function() { return solc.version(); })
   .showHelpOnFail(false, 'Specify --help for available options')
@@ -110,10 +106,7 @@ function writeFile (file, content) {
 }
 
 for (var contractName in output.contracts) {
-  var contractFileName = contractName;
-  if (argv.friendlyFilenames) {
-      contractFileName = contractFileName.replace(/[:./]/g,'');
-  }
+  var contractFileName = contractName.replace(/[:./]/g, '_');
 
   if (argv.bin) {
     writeFile(contractFileName + '.bin', output.contracts[contractName].bytecode);


### PR DESCRIPTION
On Windows systems, the ':' (colon) character is reserved and invalid in file names. This patch adds the --replace-colon option that replaces the colon with '-' (minus) in output file names.

Should fix #109