### PR TITLE
require-from-string from ^1.1.0 to 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "fs-extra": "^0.30.0",
     "memorystream": "^0.3.1",
-    "require-from-string": "^1.1.0",
+    "require-from-string": "1.2.0",
     "semver": "^5.3.0",
     "yargs": "^4.7.1"
   },


### PR DESCRIPTION
#110 #135 #143 

Tried to use `solc` in a browser with Angular (latest), but was getting an error at buildtime. This solves the problem for me.

Here is the commit in question (from their repo): https://github.com/floatdrop/require-from-string/commit/80783b2ca46daa4157241503e434f10a24bc4c67

Ran the `solc` tests. All the initial ones passed; as it got to the end there were several ENOENTS with DAO files. Perhaps I didn't fetch everything... but in general it passes.