### PR TITLE
Fix installation's error on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "lint": "semistandard",
-    "prepublish": "./downloadCurrentVersion.js && ./verifyVersion.js",
+    "prepublish": "node downloadCurrentVersion.js && node verifyVersion.js",
     "pretest": "npm run lint",
     "test": "tape ./test/index.js",
     "coverage": "istanbul cover node_modules/tape/bin/tape ./test/index.js",


### PR DESCRIPTION
I was received this error since execute `npm install` from Command Prompt:
```
'.' is not recognized as an internal or external command,
operable program or batch file.
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! solc@0.4.21 prepublish: `./downloadCurrentVersion.js && ./verifyVersion.js`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the solc@0.4.21 prepublish script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     C:\Users\chiro\AppData\Roaming\npm-cache\_logs\2018-03-23T10_31_11_253Z-debug.log
```
**Reason:**  `'.' is not recognized as an internal or external command,`