### PR TITLE
Fix linkBytecode to work properly with two-level lists

### DIFF
--- a/linker.js
+++ b/linker.js
@@ -2,7 +2,7 @@ var linkBytecode = function (bytecode, libraries) {
   // NOTE: for backwards compatibility support old compiler which didn't use file names
   var librariesComplete = {};
   for (var libraryName in libraries) {
-    if (typeof libraryName === 'object') {
+    if (typeof libraries[libraryName] === 'object') {
       // API compatible with the standard JSON i/o
       for (var lib in libraries[libraryName]) {
         librariesComplete[lib] = libraries[libraryName][lib];

--- a/test/package.js
+++ b/test/package.js
@@ -456,6 +456,20 @@ tape('Linking', function (t) {
     st.end();
   });
 
+  t.test('link properly with two-level configuration (from standard JSON)', function (st) {
+    var input = {
+      'lib.sol': 'library L { function f() returns (uint) { return 7; } }',
+      'cont.sol': 'import "lib.sol"; contract x { function g() { L.f(); } }'
+    };
+    var output = solc.compile({sources: input});
+    var bytecode = getBytecode(output, 'cont.sol', 'x');
+    st.ok(bytecode);
+    st.ok(bytecode.length > 0);
+    bytecode = solc.linkBytecode(bytecode, { 'lib.sol': { 'L': '0x123456' } });
+    st.ok(bytecode.indexOf('_') < 0);
+    st.end();
+  });
+
   t.test('linker to fail with missing library', function (st) {
     var input = {
       'lib.sol': 'library L { function f() returns (uint) { return 7; } }',


### PR DESCRIPTION
When using standard JSON i/o, input parameter `libraries` to function `linkBytecode` is of form
```
{
"myFile.sol": {
        "MyLib": "0x123123..."
      }
}
```
I believe the typeof check is meant to be applied to the value not the the key of `libraryName`