### PR TITLE
Truncate linkerObject at the beginning, not end

### DIFF
--- a/linker.js
+++ b/linker.js
@@ -20,7 +20,7 @@ var linkBytecode = function (bytecode, libraries) {
 
   for (libraryName in librariesComplete) {
     // truncate to 37 characters
-    var internalName = libraryName.slice(0, 36);
+    var internalName = libraryName.slice(-36);
     // prefix and suffix with __
     var libLabel = '__' + internalName + Array(37 - internalName.length).join('_') + '__';
 


### PR DESCRIPTION
Required change for https://github.com/ethereum/solidity/pull/3918