### PR TITLE
Change rules for selecting filename for generated files

### DIFF
--- a/solcjs
+++ b/solcjs
@@ -115,7 +115,7 @@ function writeFile (file, content) {
 }
 
 for (var contractName in output.contracts) {
-  var contractFileName = contractName.replace(/[:./]/g, '_');
+  var contractFileName = contractName.replace(/(.*):/, '');
 
   if (argv.bin) {
     writeFile(contractFileName + '.bin', output.contracts[contractName].bytecode);


### PR DESCRIPTION
Closes https://github.com/ethereum/solc-js/issues/219.
Behaviour is now the same as for native `solc`.