### PR TITLE
Remove solc.linkBytecode because the preferred one is linker.linkBytecode

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,8 +177,6 @@ var linker = require('solc/linker')
 bytecode = linker.linkBytecode(bytecode, { 'MyLibrary': '0x123456...' })
 ```
 
-(Note: `linkBytecode` is also exposed via `solc` as `solc.linkBytecode`, but this usage is deprecated.)
-
 As of Solidity 0.4.11 the compiler supports [standard JSON input and output](https://solidity.readthedocs.io/en/develop/using-the-compiler.html#compiler-input-and-output-json-description) which outputs a *link references* map. This gives a map of library names to offsets in the bytecode to replace the addresses at. It also doesn't have the limitation on library file and contract name lengths.
 
 There is a method available in the `linker` module called `findLinkReferences` which can find such link references in bytecode produced by an older compiler:

--- a/test/package.js
+++ b/test/package.js
@@ -559,7 +559,7 @@ tape('Linking', function (t) {
     var bytecode = getBytecode(output, 'cont.sol', 'x');
     st.ok(bytecode);
     st.ok(bytecode.length > 0);
-    bytecode = solc.linkBytecode(bytecode, { 'lib.sol:L': '0x123456' });
+    bytecode = linker.linkBytecode(bytecode, { 'lib.sol:L': '0x123456' });
     st.ok(bytecode.indexOf('_') < 0);
     st.end();
   });
@@ -573,7 +573,7 @@ tape('Linking', function (t) {
     var bytecode = getBytecode(output, 'cont.sol', 'x');
     st.ok(bytecode);
     st.ok(bytecode.length > 0);
-    bytecode = solc.linkBytecode(bytecode, { 'lib.sol': { 'L': '0x123456' } });
+    bytecode = linker.linkBytecode(bytecode, { 'lib.sol': { 'L': '0x123456' } });
     st.ok(bytecode.indexOf('_') < 0);
     st.end();
   });
@@ -587,7 +587,7 @@ tape('Linking', function (t) {
     var bytecode = getBytecode(output, 'cont.sol', 'x');
     st.ok(bytecode);
     st.ok(bytecode.length > 0);
-    bytecode = solc.linkBytecode(bytecode, { });
+    bytecode = linker.linkBytecode(bytecode, { });
     st.ok(bytecode.indexOf('_') >= 0);
     st.end();
   });
@@ -602,7 +602,7 @@ tape('Linking', function (t) {
     st.ok(bytecode);
     st.ok(bytecode.length > 0);
     st.throws(function () {
-      solc.linkBytecode(bytecode, { 'lib.sol:L': '' });
+      linker.linkBytecode(bytecode, { 'lib.sol:L': '' });
     });
     st.end();
   });
@@ -616,7 +616,7 @@ tape('Linking', function (t) {
     var bytecode = getBytecode(output, 'cont.sol', 'x');
     st.ok(bytecode);
     st.ok(bytecode.length > 0);
-    bytecode = solc.linkBytecode(bytecode, { 'lib.sol:L1234567890123456789012345678901234567890': '0x123456' });
+    bytecode = linker.linkBytecode(bytecode, { 'lib.sol:L1234567890123456789012345678901234567890': '0x123456' });
     st.ok(bytecode.indexOf('_') < 0);
     st.end();
   });

--- a/wrapper.js
+++ b/wrapper.js
@@ -1,6 +1,5 @@
 var assert = require('assert');
 var translate = require('./translate.js');
-var linker = require('./linker.js');
 var requireFromString = require('require-from-string');
 var https = require('https');
 var MemoryStream = require('memorystream');
@@ -232,7 +231,6 @@ function setupMethods (soljson) {
     compile: compile,
     compileStandard: compileStandard,
     compileStandardWrapper: compileStandardWrapper,
-    linkBytecode: linker.linkBytecode,
     supportsMulti: compileJSONMulti !== null,
     supportsImportCallback: compileJSONCallback !== null,
     supportsStandard: compileStandard !== null,


### PR DESCRIPTION
Part of #120.

This a 0.5.0 breaking change.