### PR TITLE
New breaking api, compile() is an alias to compileStandardWrapper()

### DIFF
--- a/test/cli.js
+++ b/test/cli.js
@@ -1,14 +1,8 @@
 const tape = require('tape');
 const spawn = require('tape-spawn');
 const pkg = require('../package.json');
-const semver = require('semver');
 
-var daodir;
-if (semver.lt(pkg.version, '0.5.0')) {
-  daodir = 'DAO040';
-} else {
-  daodir = 'DAO';
-}
+var daodir = 'DAO';
 
 tape('CLI', function (t) {
   t.test('--version', function (st) {

--- a/test/determinism.js
+++ b/test/determinism.js
@@ -1,18 +1,12 @@
 const tape = require('tape');
 const fs = require('fs');
 const solc = require('../index.js');
-const semver = require('semver');
 
 tape('Deterministic Compilation', function (t) {
   t.test('DAO', function (st) {
     var input = {};
     var prevBytecode = null;
-    var testdir;
-    if (semver.lt(solc.semver(), '0.5.0')) {
-      testdir = 'test/DAO040/';
-    } else {
-      testdir = 'test/DAO/';
-    }
+    var testdir = 'test/DAO/';
     var files = ['DAO.sol', 'Token.sol', 'TokenCreation.sol', 'ManagedAccount.sol'];
     var i;
     for (i in files) {

--- a/wrapper.js
+++ b/wrapper.js
@@ -79,20 +79,6 @@ function setupMethods (soljson) {
     };
   }
 
-  var compile = function (input, optimise, readCallback) {
-    var result = '';
-    if (readCallback !== undefined && compileJSONCallback !== null) {
-      result = compileJSONCallback(JSON.stringify(input), optimise, readCallback);
-    } else if (typeof input !== 'string' && compileJSONMulti !== null) {
-      result = compileJSONMulti(JSON.stringify(input), optimise);
-    } else if (compileJSON !== null) {
-      result = compileJSON(input, optimise);
-    } else {
-      return { errors: 'No suitable compiler interface found.' };
-    }
-    return JSON.parse(result);
-  };
-
   // Expects a Standard JSON I/O but supports old compilers
   var compileStandardWrapper = function (input, readCallback) {
     if (compileStandard !== null) {
@@ -230,13 +216,7 @@ function setupMethods (soljson) {
       compileCallback: compileJSONCallback,
       compileStandard: compileStandard
     },
-    compile: compile,
-    compileStandard: compileStandard,
-    compileStandardWrapper: compileStandardWrapper,
-    supportsSingle: compileJSON !== null,
-    supportsMulti: compileJSONMulti !== null,
-    supportsImportCallback: compileJSONCallback !== null,
-    supportsStandard: compileStandard !== null,
+    compile: compileStandardWrapper,
     // Loads the compiler of the given version from the github repository
     // instead of from the local filesystem.
     loadRemoteVersion: function (versionString, cb) {

--- a/wrapper.js
+++ b/wrapper.js
@@ -48,17 +48,17 @@ function setupMethods (soljson) {
   };
 
   var compileJSON = null;
-  if ('_compileJSON' in soljson) {
+  if ('x_compileJSON' in soljson) {
     compileJSON = soljson.cwrap('compileJSON', 'string', ['string', 'number']);
   }
 
   var compileJSONMulti = null;
-  if ('_compileJSONMulti' in soljson) {
+  if ('x_compileJSONMulti' in soljson) {
     compileJSONMulti = soljson.cwrap('compileJSONMulti', 'string', ['string', 'number']);
   }
 
   var compileJSONCallback = null;
-  if ('_compileJSONCallback' in soljson) {
+  if ('x_compileJSONCallback' in soljson) {
     var compileInternal = soljson.cwrap('compileJSONCallback', 'string', ['string', 'number', 'number']);
     compileJSONCallback = function (input, optimize, readCallback) {
       return runWithReadCallback(readCallback, compileInternal, [ input, optimize ]);
@@ -66,7 +66,7 @@ function setupMethods (soljson) {
   }
 
   var compileStandard = null;
-  if ('_compileStandard' in soljson) {
+  if ('x_compileStandard' in soljson) {
     var compileStandardInternal = soljson.cwrap('compileStandard', 'string', ['string', 'number']);
     compileStandard = function (input, readCallback) {
       return runWithReadCallback(readCallback, compileStandardInternal, [ input ]);
@@ -217,6 +217,10 @@ function setupMethods (soljson) {
       compileStandard: compileStandard
     },
     compile: compileStandardWrapper,
+
+    compileStandard: compileStandardWrapper,
+    compileStandardWrapper: compileStandardWrapper,
+
     // Loads the compiler of the given version from the github repository
     // instead of from the local filesystem.
     loadRemoteVersion: function (versionString, cb) {


### PR DESCRIPTION
Implements #120 and https://github.com/ethereum/solidity/issues/3452

This is the hard-breaking option, while #122 implements a more incremental change, but carries a lot more baggage.

Depends on #256. Needs test changes.