### PR TITLE
Use bytecode for the linker tests

### DIFF
--- a/test/package.js
+++ b/test/package.js
@@ -556,56 +556,44 @@ tape('Linking', function (t) {
   }
 
   t.test('link properly', function (st) {
-    var input = {
+    /*
       'lib.sol': 'library L { function f() public returns (uint) { return 7; } }',
       'cont.sol': 'import "lib.sol"; contract x { function g() public { L.f(); } }'
-    };
-    var output = solc.compile({sources: input});
-    var bytecode = getBytecode(output, 'cont.sol', 'x');
-    st.ok(bytecode);
-    st.ok(bytecode.length > 0);
+    */
+    var bytecode = '608060405234801561001057600080fd5b5061011f806100206000396000f300608060405260043610603f576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff168063e2179b8e146044575b600080fd5b348015604f57600080fd5b5060566058565b005b73__lib.sol:L_____________________________6326121ff06040518163ffffffff167c010000000000000000000000000000000000000000000000000000000002815260040160206040518083038186803b15801560b757600080fd5b505af415801560ca573d6000803e3d6000fd5b505050506040513d602081101560df57600080fd5b8101908080519060200190929190505050505600a165627a7a72305820ea2f6353179c181d7162544d637b7fe2d9e8da9803a0e2d9eafc2188d1d59ee30029';
     bytecode = linker.linkBytecode(bytecode, { 'lib.sol:L': '0x123456' });
     st.ok(bytecode.indexOf('_') < 0);
     st.end();
   });
 
   t.test('link properly with two-level configuration (from standard JSON)', function (st) {
-    var input = {
+    /*
       'lib.sol': 'library L { function f() public returns (uint) { return 7; } }',
       'cont.sol': 'import "lib.sol"; contract x { function g() public { L.f(); } }'
-    };
-    var output = solc.compile({sources: input});
-    var bytecode = getBytecode(output, 'cont.sol', 'x');
-    st.ok(bytecode);
-    st.ok(bytecode.length > 0);
+    */
+    var bytecode = '608060405234801561001057600080fd5b5061011f806100206000396000f300608060405260043610603f576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff168063e2179b8e146044575b600080fd5b348015604f57600080fd5b5060566058565b005b73__lib.sol:L_____________________________6326121ff06040518163ffffffff167c010000000000000000000000000000000000000000000000000000000002815260040160206040518083038186803b15801560b757600080fd5b505af415801560ca573d6000803e3d6000fd5b505050506040513d602081101560df57600080fd5b8101908080519060200190929190505050505600a165627a7a72305820ea2f6353179c181d7162544d637b7fe2d9e8da9803a0e2d9eafc2188d1d59ee30029';
     bytecode = linker.linkBytecode(bytecode, { 'lib.sol': { 'L': '0x123456' } });
     st.ok(bytecode.indexOf('_') < 0);
     st.end();
   });
 
   t.test('linker to fail with missing library', function (st) {
-    var input = {
+    /*
       'lib.sol': 'library L { function f() public returns (uint) { return 7; } }',
       'cont.sol': 'import "lib.sol"; contract x { function g() public { L.f(); } }'
-    };
-    var output = solc.compile({sources: input});
-    var bytecode = getBytecode(output, 'cont.sol', 'x');
-    st.ok(bytecode);
-    st.ok(bytecode.length > 0);
+    */
+    var bytecode = '608060405234801561001057600080fd5b5061011f806100206000396000f300608060405260043610603f576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff168063e2179b8e146044575b600080fd5b348015604f57600080fd5b5060566058565b005b73__lib.sol:L_____________________________6326121ff06040518163ffffffff167c010000000000000000000000000000000000000000000000000000000002815260040160206040518083038186803b15801560b757600080fd5b505af415801560ca573d6000803e3d6000fd5b505050506040513d602081101560df57600080fd5b8101908080519060200190929190505050505600a165627a7a72305820ea2f6353179c181d7162544d637b7fe2d9e8da9803a0e2d9eafc2188d1d59ee30029';
     bytecode = linker.linkBytecode(bytecode, { });
     st.ok(bytecode.indexOf('_') >= 0);
     st.end();
   });
 
   t.test('linker to fail with invalid address', function (st) {
-    var input = {
+    /*
       'lib.sol': 'library L { function f() public returns (uint) { return 7; } }',
       'cont.sol': 'import "lib.sol"; contract x { function g() public { L.f(); } }'
-    };
-    var output = solc.compile({sources: input});
-    var bytecode = getBytecode(output, 'cont.sol', 'x');
-    st.ok(bytecode);
-    st.ok(bytecode.length > 0);
+    */
+    var bytecode = '608060405234801561001057600080fd5b5061011f806100206000396000f300608060405260043610603f576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff168063e2179b8e146044575b600080fd5b348015604f57600080fd5b5060566058565b005b73__lib.sol:L_____________________________6326121ff06040518163ffffffff167c010000000000000000000000000000000000000000000000000000000002815260040160206040518083038186803b15801560b757600080fd5b505af415801560ca573d6000803e3d6000fd5b505050506040513d602081101560df57600080fd5b8101908080519060200190929190505050505600a165627a7a72305820ea2f6353179c181d7162544d637b7fe2d9e8da9803a0e2d9eafc2188d1d59ee30029';
     st.throws(function () {
       linker.linkBytecode(bytecode, { 'lib.sol:L': '' });
     });
@@ -613,14 +601,11 @@ tape('Linking', function (t) {
   });
 
   t.test('linker properly with truncated library name', function (st) {
-    var input = {
+    /*
       'lib.sol': 'library L1234567890123456789012345678901234567890 { function f() public returns (uint) { return 7; } }',
       'cont.sol': 'import "lib.sol"; contract x { function g() public { L1234567890123456789012345678901234567890.f(); } }'
-    };
-    var output = solc.compile({sources: input});
-    var bytecode = getBytecode(output, 'cont.sol', 'x');
-    st.ok(bytecode);
-    st.ok(bytecode.length > 0);
+    */
+    var bytecode = '608060405234801561001057600080fd5b5061011f806100206000396000f300608060405260043610603f576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff168063e2179b8e146044575b600080fd5b348015604f57600080fd5b5060566058565b005b73__lib.sol:L123456789012345678901234567__6326121ff06040518163ffffffff167c010000000000000000000000000000000000000000000000000000000002815260040160206040518083038186803b15801560b757600080fd5b505af415801560ca573d6000803e3d6000fd5b505050506040513d602081101560df57600080fd5b8101908080519060200190929190505050505600a165627a7a723058209f88ff686bd8ceb0fc08853dc1332d5ff81dbcf5af3a1e9aa366828091761f8c0029';
     bytecode = linker.linkBytecode(bytecode, { 'lib.sol:L1234567890123456789012345678901234567890': '0x123456' });
     st.ok(bytecode.indexOf('_') < 0);
     st.end();


### PR DESCRIPTION
Part of  https://github.com/ethereum/solidity/pull/5145. Part of #120.