### PR TITLE
New breaking api, compile() is an alias to compileStandardWrapper()

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ for (var contractName in output.contracts) {
 
 #### From version 0.1.6
 
+**Not available since 0.5.0**
+
 Starting from version 0.1.6, multiple files are supported with automatic import resolution by the compiler as follows:
 
 ```javascript
@@ -65,6 +67,8 @@ for (var contractName in output.contracts)
 Note that all input files that are imported have to be supplied, the compiler will not load any additional files on its own.
 
 #### From version 0.2.1
+
+**Not available since 0.5.0**
 
 Starting from version 0.2.1, a callback is supported to resolve missing imports as follows:
 
@@ -106,6 +110,10 @@ There is also a direct method, `compileStandard`, which is only present on recen
 Starting from version 0.4.20 a Semver compatible version number can be retrieved on every compiler release, including old ones, using the `semver()` method.
 
 #### From version 0.5.0
+
+Starting from version 0.5.0, `compile`, `compileStandard` and `compileStandardWrapper` all do the same thing - what `compileStandardWrapper` used to do.
+
+*Note*: with 0.5.1, `compileStandard` and `compileStandardWrapper` will be removed.
 
 Starting from version 0.5.0 the low-level functions are also exposed:
 - `solc.lowlevel.compileSingle`: the original entry point, supports only a single file

--- a/test/package.js
+++ b/test/package.js
@@ -386,7 +386,7 @@ tape('Compilation', function (t) {
       }
     };
 
-    var output = JSON.parse(solc.compileStandardWrapper(JSON.stringify(input)));
+    var output = JSON.parse(solc.compile(JSON.stringify(input)));
     var x = getBytecodeStandard(output, 'cont.sol', 'x');
     st.ok(x);
     st.ok(x.length > 0);
@@ -428,7 +428,7 @@ tape('Compilation', function (t) {
       }
     };
 
-    var output = JSON.parse(solc.compileStandardWrapper(JSON.stringify(input)));
+    var output = JSON.parse(solc.compile(JSON.stringify(input)));
     var x = getBytecodeStandard(output, 'cont.sol', 'x');
     st.ok(x);
     st.ok(x.length > 0);
@@ -508,7 +508,7 @@ tape('Loading Legacy Versions', function (t) {
           }
         }
       };
-      var output = JSON.parse(solcSnapshot.compileStandardWrapper(JSON.stringify(input)));
+      var output = JSON.parse(solcSnapshot.compile(JSON.stringify(input)));
       var x = getBytecodeStandard(output, 'cont.sol', 'x');
       st.ok(x);
       st.ok(x.length > 0);

--- a/test/package.js
+++ b/test/package.js
@@ -515,3 +515,11 @@ tape('Loading Legacy Versions', function (t) {
     });
   });
 });
+
+tape('API backwards compatibility', function (t) {
+  t.test('compileStandard and compileStandardWrapper exists', function (st) {
+    st.equal(solc.compile, solc.compileStandard);
+    st.equal(solc.compile, solc.compileStandardWrapper);
+    st.end();
+  });
+});

--- a/wrapper.js
+++ b/wrapper.js
@@ -79,20 +79,6 @@ function setupMethods (soljson) {
     };
   }
 
-  var compile = function (input, optimise, readCallback) {
-    var result = '';
-    if (readCallback !== undefined && compileJSONCallback !== null) {
-      result = compileJSONCallback(JSON.stringify(input), optimise, readCallback);
-    } else if (typeof input !== 'string' && compileJSONMulti !== null) {
-      result = compileJSONMulti(JSON.stringify(input), optimise);
-    } else if (compileJSON !== null) {
-      result = compileJSON(input, optimise);
-    } else {
-      return { errors: 'No suitable compiler interface found.' };
-    }
-    return JSON.parse(result);
-  };
-
   // Expects a Standard JSON I/O but supports old compilers
   var compileStandardWrapper = function (input, readCallback) {
     if (compileStandard !== null) {
@@ -237,13 +223,7 @@ function setupMethods (soljson) {
       importCallback: compileJSONCallback !== null || compileStandard !== null,
       nativeStandardJSON: compileStandard !== null
     },
-    compile: compile,
-    compileStandard: compileStandard,
-    compileStandardWrapper: compileStandardWrapper,
-    supportsSingle: compileJSON !== null,
-    supportsMulti: compileJSONMulti !== null,
-    supportsImportCallback: compileJSONCallback !== null,
-    supportsStandard: compileStandard !== null,
+    compile: compileStandardWrapper,
     // Loads the compiler of the given version from the github repository
     // instead of from the local filesystem.
     loadRemoteVersion: function (versionString, cb) {

--- a/wrapper.js
+++ b/wrapper.js
@@ -224,6 +224,10 @@ function setupMethods (soljson) {
       nativeStandardJSON: compileStandard !== null
     },
     compile: compileStandardWrapper,
+    // Temporary wrappers to minimise breaking with other projects.
+    // NOTE: to be removed in 0.5.1
+    compileStandard: compileStandardWrapper,
+    compileStandardWrapper: compileStandardWrapper,
     // Loads the compiler of the given version from the github repository
     // instead of from the local filesystem.
     loadRemoteVersion: function (versionString, cb) {


### PR DESCRIPTION
Closes #120. (Closes #122) Recreation of #259. Depends on #294.