### PR TITLE
Add solc.features.* listing

### DIFF
--- a/wrapper.js
+++ b/wrapper.js
@@ -230,6 +230,11 @@ function setupMethods (soljson) {
       compileCallback: compileJSONCallback,
       compileStandard: compileStandard
     },
+    features: {
+      multipleInputs: compileJSONMulti !== null || compileStandard !== null,
+      importCallback: compileJSONCallback !== null || compileStandard !== null,
+      nativeStandardJSON: compileStandard !== null
+    },
     compile: compile,
     compileStandard: compileStandard,
     compileStandardWrapper: compileStandardWrapper,


### PR DESCRIPTION
This is a more consistent way to see if a certain feature supported, than using `supportsXYZ`.

In preparation for #120.