### PR TITLE
Adds TypeScript definition for the package's supported public surface area.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -20,5 +20,5 @@ declare module "solc" {
   export type ReadCallbackResult = { contents: string } | { error: string };
   export type ReadCallback = (path: string) => ReadCallbackResult;
   export type Callbacks = { import: ReadCallback };
-  export function compile(input: string, readCallback?: Callbacks | ReadCallback): string;
+  export function compile(input: string, readCallback?: Callbacks): string;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,5 @@
+declare module "solc" {
+  export type ReadCallbackResult = { contents: string } | { error: string };
+  export type ReadCallback = (path: string) => ReadCallbackResult;
+  export function compile(input: string, readCallback?: ReadCallback): string;
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,15 @@
 declare module "solc" {
+  export function version(): string;
+  export function semver(): string;
+  export function license(): string;
+
+  export let features: {
+    legacySingleInput: boolean,
+    multipleInputs: boolean,
+    importCallback: boolean,
+    nativeStandardJSON: boolean,
+  };
+
   export type ReadCallbackResult = { contents: string } | { error: string };
   export type ReadCallback = (path: string) => ReadCallbackResult;
   export function compile(input: string, readCallback?: ReadCallback): string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,6 +3,13 @@ declare module "solc" {
   export function semver(): string;
   export function license(): string;
 
+  export let lowlevel: {
+    compileSingle: function(input: string): string;
+    compileMulti: function(input: string): string;
+    compileCallback: function(input: string): string;
+    compileStandard: function(input: string): string;
+  };
+
   export let features: {
     legacySingleInput: boolean,
     multipleInputs: boolean,
@@ -12,5 +19,6 @@ declare module "solc" {
 
   export type ReadCallbackResult = { contents: string } | { error: string };
   export type ReadCallback = (path: string) => ReadCallbackResult;
-  export function compile(input: string, readCallback?: ReadCallback): string;
+  export type Callbacks = { import: ReadCallback };
+  export function compile(input: string, readCallback?: Callbacks | ReadCallback): string;
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.5.14",
   "description": "Solidity compiler",
   "main": "index.js",
+  "types": "index.d.ts",
   "bin": {
     "solcjs": "solcjs"
   },


### PR DESCRIPTION
Note: While this function takes and returns a string, the string is really JSON with a very specific and well defined structure.  A future PR will (hopefully) add the definitions for those JSON objects.  This PR is meant to be an agreeable starting point for getting TypeScript definitions included.

Split off #205.