### PR TITLE
Provide an SMT solver callback to solc

### DIFF
--- a/smtchecker.js
+++ b/smtchecker.js
@@ -26,7 +26,7 @@ function solve (query) {
   var solverOutput = execSync(solvers[0].name + ' ' + solvers[0].params + ' ' + tmpFile.name);
   // Trigger early manual cleanup
   tmpFile.removeCallback();
-  return solverOutput.toString();
+  return { contents: outputStr };
 }
 
 // This function checks the standard JSON output for auxiliaryInputRequested,
@@ -51,7 +51,7 @@ function handleSMTQueries (inputJSON, outputJSON) {
 
   var responses = {};
   for (var query in queries) {
-    responses[query] = solve(queries[query]);
+    responses[query] = solve(queries[query]).contents;
   }
 
   // Note: all existing solved queries are replaced.
@@ -61,5 +61,6 @@ function handleSMTQueries (inputJSON, outputJSON) {
 }
 
 module.exports = {
-  handleSMTQueries: handleSMTQueries
+  handleSMTQueries: handleSMTQueries,
+  smtSolve: solve
 };

--- a/solcjs
+++ b/solcjs
@@ -5,6 +5,7 @@ var originalUncaughtExceptionListeners = process.listeners("uncaughtException");
 
 var fs = require('fs-extra');
 var path = require('path');
+
 var solc = require('./index.js');
 var smtchecker = require('./smtchecker.js');
 // FIXME: remove annoying exception catcher of Emscripten
@@ -54,29 +55,26 @@ function abort (msg) {
 if (argv['standard-json']) {
   var input = fs.readFileSync(process.stdin.fd).toString('utf8');
   var output = solc.compileStandardWrapper(input);
-
   try {
-    var inputJSON = smtchecker.handleSMTQueries(JSON.parse(input), JSON.parse(output));
-    if (inputJSON) {
-      output = solc.compileStandardWrapper(JSON.stringify(inputJSON));
+    input = smtchecker.handleSMTQueries(JSON.parse(input), JSON.parse(output));
+    if (input !== null) {
+      output = solc.compileStandardWrapper(JSON.stringify(input));
     }
-  }
-  catch (e) {
+  } catch (e) {
     var addError = {
-      component: "general",
+      component: 'general',
       formattedMessage: e.toString(),
       message: e.toString(),
-      type: "Warning"
+      type: 'Warning'
     };
 
-    var outputJSON = JSON.parse(output);
-    if (!outputJSON.errors) {
-      outputJSON.errors = []
+    output = JSON.parse(output);
+    if (!output.errors) {
+      output.errors = [];
     }
-    outputJSON.errors.push(addError);
-    output = JSON.stringify(outputJSON);
+    output.errors.push(addError);
+    output = JSON.stringify(output);
   }
-
   console.log(output);
   process.exit(0);
 } else if (files.length === 0) {
@@ -98,20 +96,24 @@ for (var i = 0; i < files.length; i++) {
   }
 }
 
-var output = JSON.parse(solc.compileStandardWrapper(JSON.stringify({
-  language: 'Solidity',
-  settings: {
-    optimizer: {
-      enabled: argv.optimize
-    },
-    outputSelection: {
-      '*': {
-        '*': [ 'abi', 'evm.bytecode' ]
+var output = JSON.parse(solc.compileStandardWrapper(
+  JSON.stringify({
+    language: 'Solidity',
+    settings: {
+      optimizer: {
+        enabled: argv.optimize
+      },
+      outputSelection: {
+        '*': {
+          '*': [ 'abi', 'evm.bytecode' ]
+        }
       }
-    }
-  },
-  sources: sources
-})));
+    },
+    sources: sources
+  }), {
+    smtCallback: smtchecker.smtSolve
+  }
+));
 
 if (!output) {
   abort('No output from compiler');

--- a/test/package.js
+++ b/test/package.js
@@ -353,7 +353,7 @@ tape('Compilation', function (t) {
       }
     }
 
-    var output = JSON.parse(solc.lowlevel.compileStandard(JSON.stringify(input), findImports));
+    var output = JSON.parse(solc.lowlevel.compileStandard(JSON.stringify(input), { readCallback: findImports }));
     st.ok(bytecodeExists(output, 'cont.sol', 'x'));
     st.ok(bytecodeExists(output, 'lib.sol', 'L'));
     st.end();


### PR DESCRIPTION
Maybe this is what was intended in the first place.
If the smtchecker is used only by `solcjs --standard-json` the development frameworks still don't use it. By moving it to `compileStandardWrapper` it works out of the box (when it's released and the frameworks update their solc versions).
Example using truffle (after updating solc manually):
```
$ truffle compile
Compiling ./contracts/assert.sol...

Compilation warnings encountered:

Warning: This is a pre-release compiler version, please do not use it in production.
,/home/leonardo/devel/truffle_test/contracts/assert.sol:7:3: Warning: Assertion violation happens here
		assert(x > 0);
		^-----------^
  for:
  x = 0
```