### PR TITLE
Fix translate.escapeString to actually replace all occurrances

### DIFF
--- a/translate.js
+++ b/translate.js
@@ -150,9 +150,9 @@ function translateJsonCompilerOutput (output, libraries) {
 
 function escapeString (text) {
   return text
-    .replace('\n', '\\n', 'g')
-    .replace('\r', '\\r', 'g')
-    .replace('\t', '\\t', 'g');
+    .replace(/\n/, '\\n')
+    .replace(/\r/, '\\r')
+    .replace(/\t/, '\\t');
 }
 
 function formatAssemblyText (asm, prefix, source) {


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace:
> str.replace(regexp|substr, newSubstr|function)
> The replace() method returns a new string with some or all matches of a pattern replaced by a replacement. The pattern can be a string or a RegExp, and the replacement can be a string or a function to be called for each match. If pattern is a string, only the first occurrence will be replaced.

The original code had an unused argument and it always replaced the first match only.