### PR TITLE
Force tape version to 4.9.2.

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "ethereumjs-util": "^5.2.0",
     "istanbul": "^0.4.5",
     "semistandard": "^12.0.0",
-    "tape": "^4.9.1",
+    "tape": "=4.9.2",
     "tape-spawn": "^1.4.2"
   },
   "semistandard": {


### PR DESCRIPTION
A new tape version was released two days ago which makes our test setup fail. I'm still not sure whether it is a bug with our tests or with tape, but this should get us through the release tomorrow.

I'm suspecting [this PR](https://github.com/substack/tape/pull/403) being the cause of it.