### PR TITLE
Removes ethereumjs-util and keccak dependencies.

### DIFF
--- a/downloadCurrentVersion.js
+++ b/downloadCurrentVersion.js
@@ -7,7 +7,7 @@ var pkg = require('./package.json');
 var fs = require('fs');
 var https = require('https');
 var MemoryStream = require('memorystream');
-var ethJSUtil = require('ethereumjs-util');
+var keccak256 = require('js-sha3').keccak256;
 
 function getVersionList (cb) {
   console.log('Retrieving available version list...');
@@ -48,7 +48,7 @@ function downloadBinary (outputName, version, expectedHash) {
     response.pipe(file);
     file.on('finish', function () {
       file.close(function () {
-        var hash = '0x' + ethJSUtil.sha3(fs.readFileSync(outputName, { encoding: 'binary' })).toString('hex');
+        var hash = '0x' + keccak256(fs.readFileSync(outputName, { encoding: 'binary' }));
         if (expectedHash !== hash) {
           console.log('Hash mismatch: ' + expectedHash + ' vs ' + hash);
           process.exit(1);

--- a/linker.js
+++ b/linker.js
@@ -1,11 +1,7 @@
-var keccak = require('keccak');
-
-function keccak256 (input) {
-  return keccak('keccak256').update(input).digest();
-}
+var keccak256 = require('js-sha3').keccak256;
 
 function libraryHashPlaceholder (input) {
-  return '$' + keccak256(input).toString('hex').slice(0, 34) + '$';
+  return '$' + keccak256(input).slice(0, 34) + '$';
 }
 
 var linkBytecode = function (bytecode, libraries) {

--- a/package.json
+++ b/package.json
@@ -43,16 +43,15 @@
   "dependencies": {
     "command-exists": "^1.2.8",
     "fs-extra": "^0.30.0",
-    "keccak": "^1.0.2",
     "memorystream": "^0.3.1",
     "require-from-string": "^2.0.0",
     "semver": "^5.5.0",
+    "js-sha3": "0.8.0",
     "tmp": "0.0.33",
     "yargs": "^11.0.0"
   },
   "devDependencies": {
     "coveralls": "^3.0.0",
-    "ethereumjs-util": "^5.2.0",
     "istanbul": "^0.4.5",
     "semistandard": "^12.0.0",
     "tape": "=4.9.2",


### PR DESCRIPTION
Replaces both with `js-sha3`.  `ethereumjs-util` and `keccak` NPM packages both have native bindings in their dependency tree which means they depend on node-gyp along the way.  `js-sha3` on the other hand is a JavaScript-native implementation of the sha3 family of hashing functions, which relieves a number of `node-gyp` and native binding related issues.

Fixes #356 