### PR TITLE
Require tape ^4.11.0 instead of fixing tape 4.9.2.

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "coveralls": "^3.0.0",
     "istanbul": "^0.4.5",
     "semistandard": "^12.0.0",
-    "tape": "=4.9.2",
+    "tape": "^4.11.0",
     "tape-spawn": "^1.4.2"
   },
   "semistandard": {


### PR DESCRIPTION
This is the complementary test PR to https://github.com/ethereum/solidity/pull/7199.

Fixes https://github.com/ethereum/solidity/issues/5963. Closes https://github.com/ethereum/solidity/pull/7199