### PR TITLE
Export load and loadRemoteVersion without loading a compiler

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
 const wrapper = require('./wrapper.js');
 
-module.exports = wrapper(require('./soljson.js'));
+module.exports = wrapper.load(require('./soljson.js'));


### PR DESCRIPTION
The goal of this change is to load a remote compiler version without loading a local one.