### PR TITLE
Use GitHub raw.githubusercontent.com to avoid rate limiting

### DIFF
--- a/downloadCurrentVersion.js
+++ b/downloadCurrentVersion.js
@@ -13,7 +13,7 @@ function getVersionList (cb) {
   console.log('Retrieving available version list...');
 
   var mem = new MemoryStream(null, { readable: false });
-  https.get('https://ethereum.github.io/solc-bin/bin/list.json', function (response) {
+  https.get('https://raw.githubusercontent.com/ethereum/solc-bin/gh-pages/bin/list.json', function (response) {
     if (response.statusCode !== 200) {
       console.log('Error downloading file: ' + response.statusCode);
       process.exit(1);
@@ -40,7 +40,7 @@ function downloadBinary (outputName, version, expectedHash) {
   });
 
   var file = fs.createWriteStream(outputName, { encoding: 'binary' });
-  https.get('https://ethereum.github.io/solc-bin/bin/' + version, function (response) {
+  https.get('https://raw.githubusercontent.com/ethereum/solc-bin/gh-pages/bin/' + version, function (response) {
     if (response.statusCode !== 200) {
       console.log('Error downloading file: ' + response.statusCode);
       process.exit(1);

--- a/wrapper.js
+++ b/wrapper.js
@@ -328,7 +328,7 @@ function setupMethods (soljson) {
     // instead of from the local filesystem.
     loadRemoteVersion: function (versionString, cb) {
       var mem = new MemoryStream(null, {readable: false});
-      var url = 'https://ethereum.github.io/solc-bin/bin/soljson-' + versionString + '.js';
+      var url = 'https://raw.githubusercontent.com/ethereum/solc-bin/gh-pages/bin/soljson-' + versionString + '.js';
       https.get(url, function (response) {
         if (response.statusCode !== 200) {
           cb(new Error('Error retrieving binary: ' + response.statusMessage));


### PR DESCRIPTION
Fixes #445.

- Rate limit is being hit causing flakey builds for anyone who depends on solc-js remote downloading in their software. The change to GitHub raw URLs avoids hitting rate limits.
- ~~Ability to override the repository all together with an environment variable `SOLC_REPO`. Allowing people to use alternative repos, including internal.~~