### PR TITLE
 Ability to override remote download URL with env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,20 @@ solc.loadRemoteVersion('latest', function(err, solcSnapshot) {
 });
 ```
 
+### Overriding the Remote Repository
+
+When using the high-level API for downloading remote solc versions, by default the repository location is 
+the [solc-bin repository]((https://github.com/ethereum/solc-bin/tree/gh-pages/bin)) in GitHub. 
+
+When overriding, ensure the file structure & names are in the same format as the default repository. 
+
+This repository can be overridden to allow for pointing to internal/other repositories with the `SOLC_REPO` environment 
+variable.
+
+```bash
+SOLC_REPO=https://s3bucket.domain.com solcjs --help 
+``` 
+
 ### Linking Bytecode
 
 When using libraries, the resulting bytecode will contain placeholders for the real addresses of the referenced libraries. These have to be updated, via a process called linking, before deploying the contract.

--- a/downloadCurrentVersion.js
+++ b/downloadCurrentVersion.js
@@ -13,7 +13,7 @@ function getVersionList (cb) {
   console.log('Retrieving available version list...');
 
   var mem = new MemoryStream(null, { readable: false });
-  https.get('https://ethereum.github.io/solc-bin/bin/list.json', function (response) {
+  https.get('https://raw.githubusercontent.com/ethereum/solc-bin/gh-pages/bin/list.json', function (response) {
     if (response.statusCode !== 200) {
       console.log('Error downloading file: ' + response.statusCode);
       process.exit(1);
@@ -40,7 +40,7 @@ function downloadBinary (outputName, version, expectedHash) {
   });
 
   var file = fs.createWriteStream(outputName, { encoding: 'binary' });
-  https.get('https://ethereum.github.io/solc-bin/bin/' + version, function (response) {
+  https.get('https://raw.githubusercontent.com/ethereum/solc-bin/gh-pages/bin/' + version, function (response) {
     if (response.statusCode !== 200) {
       console.log('Error downloading file: ' + response.statusCode);
       process.exit(1);

--- a/downloadCurrentVersion.js
+++ b/downloadCurrentVersion.js
@@ -3,6 +3,8 @@
 // This is used to download the correct binary version
 // as part of the prepublish step.
 
+const SOLC_REPO = process.env.SOLC_REPO || 'https://raw.githubusercontent.com/ethereum/solc-bin/gh-pages/bin';
+
 var pkg = require('./package.json');
 var fs = require('fs');
 var https = require('https');
@@ -13,7 +15,7 @@ function getVersionList (cb) {
   console.log('Retrieving available version list...');
 
   var mem = new MemoryStream(null, { readable: false });
-  https.get('https://raw.githubusercontent.com/ethereum/solc-bin/gh-pages/bin/list.json', function (response) {
+  https.get(SOLC_REPO + '/list.json', function (response) {
     if (response.statusCode !== 200) {
       console.log('Error downloading file: ' + response.statusCode);
       process.exit(1);
@@ -40,7 +42,7 @@ function downloadBinary (outputName, version, expectedHash) {
   });
 
   var file = fs.createWriteStream(outputName, { encoding: 'binary' });
-  https.get('https://raw.githubusercontent.com/ethereum/solc-bin/gh-pages/bin/' + version, function (response) {
+  https.get(SOLC_REPO + '/' + version, function (response) {
     if (response.statusCode !== 200) {
       console.log('Error downloading file: ' + response.statusCode);
       process.exit(1);

--- a/wrapper.js
+++ b/wrapper.js
@@ -328,7 +328,7 @@ function setupMethods (soljson) {
     // instead of from the local filesystem.
     loadRemoteVersion: function (versionString, cb) {
       var mem = new MemoryStream(null, {readable: false});
-      var url = 'https://ethereum.github.io/solc-bin/bin/soljson-' + versionString + '.js';
+      var url = 'https://raw.githubusercontent.com/ethereum/solc-bin/gh-pages/bin/soljson-' + versionString + '.js';
       https.get(url, function (response) {
         if (response.statusCode !== 200) {
           cb(new Error('Error retrieving binary: ' + response.statusMessage));


### PR DESCRIPTION
When using the CLI/high-level API, add the ability to override the remote download URL with the `SOLC_REPO` environment variable.