### PR TITLE
Pass the wasm signature to addFunction.

### DIFF
--- a/wrapper.js
+++ b/wrapper.js
@@ -140,7 +140,7 @@ function setupMethods (soljson) {
     var addFunction = soljson.addFunction || soljson.Runtime.addFunction;
     var removeFunction = soljson.removeFunction || soljson.Runtime.removeFunction;
 
-    var cb = addFunction(singleCallback);
+    var cb = addFunction(singleCallback, 'viiiii');
     var output;
     try {
       args.push(cb);


### PR DESCRIPTION
This should be backwards compatible just as it is, shouldn't it? Let's see what the tests say.
Relates to https://github.com/ethereum/solidity/pull/9111