### PR TITLE
Getting soljson.js via dedicated solc-bin.ethereum.org domain

### DIFF
--- a/downloadCurrentVersion.js
+++ b/downloadCurrentVersion.js
@@ -13,7 +13,7 @@ function getVersionList (cb) {
   console.log('Retrieving available version list...');
 
   var mem = new MemoryStream(null, { readable: false });
-  https.get('https://raw.githubusercontent.com/ethereum/solc-bin/gh-pages/bin/list.json', function (response) {
+  https.get('https://solc-bin.ethereum.org/bin/list.json', function (response) {
     if (response.statusCode !== 200) {
       console.log('Error downloading file: ' + response.statusCode);
       process.exit(1);
@@ -40,7 +40,7 @@ function downloadBinary (outputName, version, expectedHash) {
   });
 
   var file = fs.createWriteStream(outputName, { encoding: 'binary' });
-  https.get('https://raw.githubusercontent.com/ethereum/solc-bin/gh-pages/bin/' + version, function (response) {
+  https.get('https://solc-bin.ethereum.org/bin/' + version, function (response) {
     if (response.statusCode !== 200) {
       console.log('Error downloading file: ' + response.statusCode);
       process.exit(1);

--- a/test/compiler.js
+++ b/test/compiler.js
@@ -813,7 +813,7 @@ const versions = [
 ];
 for (var version in versions) {
   version = versions[version];
-  execSync(`curl -o /tmp/${version}.js https://solc-bin.ethereum.org/bin/soljson-${version}.js`);
+  execSync(`curl -L -o /tmp/${version}.js https://solc-bin.ethereum.org/bin/soljson-${version}.js`);
   const newSolc = require('../wrapper.js')(require(`/tmp/${version}.js`));
   runTests(newSolc, version);
 }

--- a/test/compiler.js
+++ b/test/compiler.js
@@ -813,7 +813,7 @@ const versions = [
 ];
 for (var version in versions) {
   version = versions[version];
-  execSync(`curl -o /tmp/${version}.js https://ethereum.github.io/solc-bin/bin/soljson-${version}.js`);
+  execSync(`curl -o /tmp/${version}.js https://solc-bin.ethereum.org/bin/soljson-${version}.js`);
   const newSolc = require('../wrapper.js')(require(`/tmp/${version}.js`));
   runTests(newSolc, version);
 }

--- a/wrapper.js
+++ b/wrapper.js
@@ -328,7 +328,7 @@ function setupMethods (soljson) {
     // instead of from the local filesystem.
     loadRemoteVersion: function (versionString, cb) {
       var mem = new MemoryStream(null, {readable: false});
-      var url = 'https://raw.githubusercontent.com/ethereum/solc-bin/gh-pages/bin/soljson-' + versionString + '.js';
+      var url = 'https://solc-bin.ethereum.org/bin/soljson-' + versionString + '.js';
       https.get(url, function (response) {
         if (response.statusCode !== 200) {
           cb(new Error('Error retrieving binary: ' + response.statusMessage));


### PR DESCRIPTION
Currently `solc-js` is not using [solc-bin.ethereum.org](https://solc-bin.ethereum.org) domain to get `soljson.js` binaries from `solc-bin` repository. Instead it fetches the files from [raw.githubusercontent.com](https://raw.githubusercontent.com) URLs. This prevents us from freely reorganizing the structure of `solc-bin` since, unlike Github Pages, it does not provide the original file content when you access it via a symlink. Instead you get a text file with a path and `sojc-js` can't handle that currently (https://github.com/ethereum/solc-bin/pull/43, https://github.com/ethereum/solc-bin/pull/44).

Not using a domain under our control is also an obstacle to transparently moving files to a different hosting and this is exactly what we're facing now (see https://github.com/ethereum/solidity/issues/9258). We can fix it in newer versions of `solc-js` but the old ones will keep trying to get them from the old location.

This PR fixes the immediate issue by switching the URLs to [solc-bin.ethereum.org](https://solc-bin.ethereum.org). I originally assumed this to be just an oversight but after browsing through issues and PRs in this repo I see that the switch to [raw.githubusercontent.com](https://raw.githubusercontent.com) was actually intentional (#446, #445). It seems that the reason was that GH pages are rate-limited. This means that switching to the official domain would bring the problem back as it's currently pointing at GH pages too. I'm in the process of preparing an Amazon S3 bucket to mirror `solc-bin` content and I think I'll have to keep this PR as a draft until that's ready and the official domain is pointing at it.