### PR TITLE
Following HTTP redirects

### DIFF
--- a/downloadCurrentVersion.js
+++ b/downloadCurrentVersion.js
@@ -5,7 +5,7 @@
 
 var pkg = require('./package.json');
 var fs = require('fs');
-var https = require('https');
+var https = require('follow-redirects').https;
 var MemoryStream = require('memorystream');
 var keccak256 = require('js-sha3').keccak256;
 

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "memorystream": "^0.3.1",
     "require-from-string": "^2.0.0",
     "semver": "^5.5.0",
-    "tmp": "0.0.33"
+    "tmp": "0.0.33",
+    "follow-redirects": "^1.12.1"
   },
   "devDependencies": {
     "coveralls": "^3.0.0",

--- a/wrapper.js
+++ b/wrapper.js
@@ -1,7 +1,7 @@
 var assert = require('assert');
 var translate = require('./translate.js');
 var requireFromString = require('require-from-string');
-var https = require('https');
+var https = require('follow-redirects').https;
 var MemoryStream = require('memorystream');
 var semver = require('semver');
 


### PR DESCRIPTION
Requested in https://github.com/ethereum/solc-js/pull/479#discussion_r457598976

This PR adds a dependency on [follow-redirects](https://github.com/follow-redirects/follow-redirects) which has no dependencies of its own and consists of a single `.js` file (not counting the `http.js`/`https.js`/`debug.js` stubs). It has a few dev dependencies but we're already using most of them (`node_modules/` gets just 100 kB bigger after installing them on my machine).

It doesn't really do all that much (most of its code is stuff we don't need right now: callback handling, configuration options, HTTP methods other than `GET`) so it wouldn't be hard to write from scratch but I think it's already small enough.