### PR TITLE
Proper SMT CHC tests

### DIFF
--- a/smtchecker.js
+++ b/smtchecker.js
@@ -25,10 +25,10 @@ function handleSMTQueries (inputJSON, outputJSON, solver) {
   return inputJSON;
 }
 
-function smtCallback (solver) {
+function smtCallback (solverFunction, solver) {
   return function (query) {
     try {
-      var result = solver(query);
+      var result = solverFunction(query, solver);
       return { contents: result };
     } catch (err) {
       return { error: err };

--- a/smtsolver.js
+++ b/smtsolver.js
@@ -3,12 +3,13 @@ var execSync = require('child_process').execSync;
 var fs = require('fs');
 var tmp = require('tmp');
 
+// Timeout in ms.
 const timeout = 10000;
 
 var potentialSolvers = [
   {
     name: 'z3',
-    params: '-smt2 rlimit=20000000 rewriter.pull_cheap_ite=true fp.spacer.q3.use_qgen=true fp.spacer.mbqi=false fp.spacer.ground_pobs=false'
+    params: '-smt2 timeout=' + timeout + ' rewriter.pull_cheap_ite=true fp.spacer.q3.use_qgen=true fp.spacer.mbqi=false fp.spacer.ground_pobs=false'
   },
   {
     name: 'cvc4',

--- a/smtsolver.js
+++ b/smtsolver.js
@@ -45,7 +45,9 @@ function solve (query) {
     if (
       !solverOutput.startsWith('sat') &&
       !solverOutput.startsWith('unsat') &&
-      !solverOutput.startsWith('unknown')
+      !solverOutput.startsWith('unknown') &&
+      !solverOutput.startsWith('(error') &&
+      !solverOutput.startsWith('error')
     ) {
       throw new Error('Failed to solve SMT query. ' + e.toString());
     }

--- a/smtsolver.js
+++ b/smtsolver.js
@@ -4,29 +4,28 @@ var fs = require('fs');
 var tmp = require('tmp');
 
 // Timeout in seconds.
-const timeout = 1000;
+const timeout = 300;
 
 var potentialSolvers = [
   {
     name: 'Eldarica Vanilla',
     command: 'eld',
-    params: '-horn -t:' + timeout
+    params: '-horn'
   },
   {
     name: 'Eldarica No Abstraction',
     command: 'eld',
-    params: '-horn -ssol -t:' + timeout + ' -abstract:off'
-  }
-  /*
+    params: '-horn -abstract:off'
+  },
   {
     name: 'Eldarica Term Abstraction',
     command: 'eld',
-    params: '-horn -t:' + timeout + ' -abstract:term'
+    params: '-horn -abstract:term'
   },
   {
     name: 'Eldarica Oct Abstraction',
     command: 'eld',
-    params: '-horn -t:' + timeout + ' -abstract:oct'
+    params: '-horn -abstract:oct'
   },
   {
     name: 'Spacer Vanilla',
@@ -38,7 +37,6 @@ var potentialSolvers = [
     command: 'z3',
     params: '-smt2 timeout=' + (timeout * 1000) + ' rewriter.pull_cheap_ite=true fp.spacer.q3.use_qgen=true fp.spacer.mbqi=false fp.spacer.ground_pobs=false'
   }
-  */
 /*
   {
     name: 'z3',
@@ -65,7 +63,10 @@ function solve (query, solver) {
   try {
     solverOutput = execSync(
       solver.command + ' ' + solver.params + ' ' + tmpFile.name, {
-        stdio: 'pipe'
+        encoding: 'utf8',
+        maxBuffer: 1024 * 1024 * 1024,
+        stdio: 'pipe',
+        timeout: timeout * 1000
       }
     ).toString();
   } catch (e) {

--- a/smtsolver.js
+++ b/smtsolver.js
@@ -4,14 +4,20 @@ var fs = require('fs');
 var tmp = require('tmp');
 
 // Timeout in seconds.
-const timeout = 10;
+const timeout = 1000;
 
 var potentialSolvers = [
   {
+    name: 'Eldarica Vanilla',
+    command: 'eld',
+    params: '-horn -t:' + timeout
+  },
+  {
     name: 'Eldarica No Abstraction',
     command: 'eld',
-    params: '-horn -t:' + timeout + ' -abstract:off'
-  },
+    params: '-horn -ssol -t:' + timeout + ' -abstract:off'
+  }
+  /*
   {
     name: 'Eldarica Term Abstraction',
     command: 'eld',
@@ -32,6 +38,7 @@ var potentialSolvers = [
     command: 'z3',
     params: '-smt2 timeout=' + (timeout * 1000) + ' rewriter.pull_cheap_ite=true fp.spacer.q3.use_qgen=true fp.spacer.mbqi=false fp.spacer.ground_pobs=false'
   }
+  */
 /*
   {
     name: 'z3',
@@ -50,12 +57,14 @@ function solve (query, solver) {
     throw new Error('No SMT solver available. Assertion checking will not be performed.');
   }
 
+  console.log("Running solver " + solver.name);
   var tmpFile = tmp.fileSync({ postfix: '.smt2' });
   fs.writeFileSync(tmpFile.name, query);
+  console.log(query);
   var solverOutput;
   try {
     solverOutput = execSync(
-      solvers[0].command + ' ' + solvers[0].params + ' ' + tmpFile.name, {
+      solver.command + ' ' + solver.params + ' ' + tmpFile.name, {
         stdio: 'pipe'
       }
     ).toString();
@@ -76,8 +85,8 @@ function solve (query, solver) {
   }
   // Trigger early manual cleanup
   tmpFile.removeCallback();
-  //console.log("OUTPUT IS");
-  //console.log(solverOutput);
+  console.log("OUTPUT IS");
+  console.log(solverOutput);
   return solverOutput;
 }
 

--- a/smtsolver.js
+++ b/smtsolver.js
@@ -4,7 +4,7 @@ var fs = require('fs');
 var tmp = require('tmp');
 
 // Timeout in ms.
-const timeout = 10000;
+const timeout = 1000;
 
 var potentialSolvers = [
   {

--- a/smtsolver.js
+++ b/smtsolver.js
@@ -9,7 +9,7 @@ const timeout = 1000;
 var potentialSolvers = [
   {
     name: 'z3',
-    params: '-smt2 timeout=' + timeout + ' rewriter.pull_cheap_ite=true fp.spacer.q3.use_qgen=true fp.spacer.mbqi=false fp.spacer.ground_pobs=false'
+    params: ' timeout=' + timeout + ' rewriter.pull_cheap_ite=true fp.spacer.q3.use_qgen=true fp.spacer.mbqi=false fp.spacer.ground_pobs=false'
   },
   {
     name: 'cvc4',
@@ -25,6 +25,7 @@ function solve (query) {
 
   var tmpFile = tmp.fileSync({ postfix: '.smt2' });
   fs.writeFileSync(tmpFile.name, query);
+  console.log(query);
   // TODO For now only the first SMT solver found is used.
   // At some point a computation similar to the one done in
   // SMTPortfolio::check should be performed, where the results
@@ -54,6 +55,8 @@ function solve (query) {
   }
   // Trigger early manual cleanup
   tmpFile.removeCallback();
+  console.log("OUTPUT IS");
+  console.log(solverOutput);
   return solverOutput;
 }
 

--- a/solcjs
+++ b/solcjs
@@ -53,8 +53,12 @@ function stripBasePath(path) {
 }
 
 var callbacks = undefined
-if (program.basePath)
-  callbacks = {'import': readFileCallback};
+if (program.basePath) {
+  callbacks = {
+    'import': readFileCallback,
+    'smtSolver': smtchecker.smtCallback(smtsolver.smtSolver, smtsolver.availableSolvers[1])
+  };
+}
 
 if (program.standardJson) {
   var input = fs.readFileSync(process.stdin.fd).toString('utf8');

--- a/test/smtCheckerTests/smoke.sol
+++ b/test/smtCheckerTests/smoke.sol
@@ -1,5 +1,0 @@
-pragma experimental SMTChecker;
-contract C {
-	function f() public pure {
-	}
-}

--- a/test/smtCheckerTests/smoke_with_engine.sol
+++ b/test/smtCheckerTests/smoke_with_engine.sol
@@ -1,6 +1,0 @@
-contract C {
-	function f() public pure {
-	}
-}
-// ====
-// SMTEngine: all

--- a/test/smtCheckerTests/smoke_with_multi_engine.sol
+++ b/test/smtCheckerTests/smoke_with_multi_engine.sol
@@ -1,8 +1,0 @@
-pragma experimental SMTChecker;
-contract C {
-	function f() public pure {
-	}
-}
-// ====
-// SMTEngine: all
-// SMTEngine: chc

--- a/test/smtcallback.js
+++ b/test/smtcallback.js
@@ -63,6 +63,7 @@ function buildErrorsDict (errors) {
 }
 
 function compareResults (results) {
+  console.log(results);
   assert(results.length >= 2);
   const allProperties = results.reduce((acc, v) => { return {...acc, ...v}; });
   const isSafe = (d, r) => !(r in d);

--- a/test/smtcallback.js
+++ b/test/smtcallback.js
@@ -297,9 +297,9 @@ tape('SMTCheckerCallback', function (t) {
       const test = tests[i];
       st.comment('Running ' + i + ' ...');
       let results = [];
-      let solvers = ['z3'];
+      let solvers = [];
       // 0.8.5 introduced the `solvers` option,
-      // so we can test the statica z3 inside soljson
+      // so we can test the static z3 inside soljson
       // and a local solver as well.
       if (semver.gt(solc.semver(), '0.8.4')) {
         solvers.push('smtlib2');
@@ -310,7 +310,12 @@ tape('SMTCheckerCallback', function (t) {
         // `pragma experimental SMTChecker;` was deprecated in 0.8.4
         if (semver.gt(solc.semver(), '0.8.3')) {
           const engine = test.engine !== undefined ? test.engine : 'all';
-          settings = { modelChecker: { engine: engine } };
+          settings = { modelChecker: {
+            engine: engine,
+            targets: ['assert'],
+            divModWithSlacks: false,
+            showUnproved: true
+          } };
 
           // 0.8.5 introduced the `solvers` option.
           if (semver.gt(solc.semver(), '0.8.4')) {

--- a/test/smtcallback.js
+++ b/test/smtcallback.js
@@ -75,7 +75,7 @@ function compareResults (results) {
     // If one solver does not have the location, the property is safe.
     const safe = results.reduce((acc, v) => acc || isSafe(v, loc), false);
     // If one solver reports the location as solved, the property is unsafe.
-    const unsafe = !safe && results.reduce((acc, v) => acc || isUnsafe(v, loc), false);
+    const unsafe = results.reduce((acc, v) => acc || isUnsafe(v, loc), false);
 
     const info = loc.split('-'); // [bmc or chc, start:end]
     // Contradiction found.


### PR DESCRIPTION
Depends on https://github.com/ethereum/solidity/pull/11421

This PR adds *proper* SMTChecker tests. Currently, the SMTChecker tests are actually broken, many tests are ignored, and the smtlib version of the SMTCheckre encoding is not being tests at all.

The main `smtCheckerTests` in this code are mainly used by the Solidity `t_ems_solcjs` job, which copies the `smtCheckerTests` into the `solc-js` tests and runs `test/smtcallback.js` from this repo. It now requires `soljson` version `>=0.7.2` because of the warning format.

If `soljson < 0.8.5`, it runs the static `z3` inside `soljson` and compares that to the test expectation.
Else, it runs /\ plus a local `z3` binary using Solidity's `smtlib2` encoding, and compares all of them.
The comparison now is much more precise than before: it compares each output location, which represents a property.

Note that safe properties are not reported, so if one solver reports a location and another doesn't, there's an inconsistency. The exception to this is when this inconsistency happens for the BMC engine, where one solver probably solved it safe with CHC, and another solver couldn't prove it safe with CHC, and reports an unsafe false positive via BMC.

The test only fails if there's a real inconsistency, as opposed to the stronger `soltest`. I think that's fair since the JS/smtlib2 environment might give more nondeterministic answers compared to the embedded C++ z3.