### PR TITLE
Use minimal optimizer settings in solcjs when --optimize flag is missing

### DIFF
--- a/solcjs
+++ b/solcjs
@@ -18,7 +18,7 @@ program.name('solcjs');
 program.version(solc.version());
 program
   .option('--version', 'Show version and exit.')
-  .option('--optimize', 'Enable bytecode optimizer.')
+  .option('--optimize', 'Enable bytecode optimizer.', false)
   .option('--bin', 'Binary of the contracts in hex.')
   .option('--abi', 'ABI of the contracts.')
   .option('--standard-json', 'Turn on Standard JSON Input / Output mode.')


### PR DESCRIPTION
Fixes #527.
Related to https://github.com/ethereum/solidity/issues/11521.

Currently the default value of the flag is indefined so `enabled` key gets stripped from the optimizer settings dict and we and up with `OptimiserSettings::none()` rather than `OptimiserSettings::minimal()`.