### PR TITLE
[solcjs] Base path stripping matching `solc`

### DIFF
--- a/solcjs
+++ b/solcjs
@@ -4,6 +4,7 @@
 var originalUncaughtExceptionListeners = process.listeners("uncaughtException");
 
 var fs = require('fs-extra');
+var os = require('os');
 var path = require('path');
 var solc = require('./index.js');
 var smtchecker = require('./smtchecker.js');
@@ -45,11 +46,32 @@ function readFileCallback(sourcePath) {
   } else
     return { error: 'File not found at ' + sourcePath}
 }
+
+function withUnixPathSeparators(filePath) {
+  if (os.platform !== 'win32')
+    // On UNIX-like systems forward slashes in paths are just a part of the file name.
+    return filePath;
+
+  return filePath.replace(/\\/g, "/");
+}
+
 function stripBasePath(sourcePath) {
-  if (program.basePath && sourcePath.startsWith(program.basePath))
-    return sourcePath.slice(program.basePath.length);
-  else
-    return sourcePath;
+  const absoluteBasePath = (program.basePath ? path.resolve(program.basePath) : path.resolve('.'));
+
+  // Compared to base path stripping logic in solc this is much simpler because path.resolve()
+  // handles symlinks correctly (does not resolve them except in work dir) and strips .. segments
+  // from paths going beyond root (e.g. `/../../a/b/c` -> `/a/b/c/`). It's simpler also because it
+  // ignores less important corner cases: drive letters are not stripped from absolute paths on
+  // Windows and UNC paths are not handled in a special way (at least on Linux). Finally, it has
+  // very little test coverage so there might be more differences that we are just not aware of.
+  const absoluteSourcePath = path.resolve(sourcePath);
+  const relativeSourcePath = path.relative(absoluteBasePath, absoluteSourcePath);
+
+  if (relativeSourcePath.startsWith('../'))
+    // Path can't be made relative without stepping outside of base path so return absolute one.
+    return withUnixPathSeparators(absoluteSourcePath);
+
+  return withUnixPathSeparators(relativeSourcePath);
 }
 
 var callbacks = undefined

--- a/solcjs
+++ b/solcjs
@@ -36,7 +36,8 @@ function abort (msg) {
 }
 
 function readFileCallback(sourcePath) {
-  sourcePath = program.basePath + '/' + sourcePath;
+  if (program.basePath)
+    sourcePath = program.basePath + '/' + sourcePath;
   if (fs.existsSync(sourcePath)) {
     try {
       return { 'contents': fs.readFileSync(sourcePath).toString('utf8') }
@@ -75,7 +76,7 @@ function stripBasePath(sourcePath) {
 }
 
 var callbacks = undefined
-if (program.basePath)
+if (program.basePath || !program.standardJson)
   callbacks = {'import': readFileCallback};
 
 if (program.standardJson) {

--- a/solcjs
+++ b/solcjs
@@ -34,22 +34,22 @@ function abort (msg) {
   process.exit(1);
 }
 
-function readFileCallback(path) {
-  path = program.basePath + '/' + path;
-  if (fs.existsSync(path)) {
+function readFileCallback(sourcePath) {
+  sourcePath = program.basePath + '/' + sourcePath;
+  if (fs.existsSync(sourcePath)) {
     try {
-      return { 'contents': fs.readFileSync(path).toString('utf8') }
+      return { 'contents': fs.readFileSync(sourcePath).toString('utf8') }
     } catch (e) {
-      return { error: 'Error reading ' + path + ': ' + e };
+      return { error: 'Error reading ' + sourcePath + ': ' + e };
     }
   } else
-    return { error: 'File not found at ' + path}
+    return { error: 'File not found at ' + sourcePath}
 }
-function stripBasePath(path) {
-  if (program.basePath && path.startsWith(program.basePath))
-    return path.slice(program.basePath.length);
+function stripBasePath(sourcePath) {
+  if (program.basePath && sourcePath.startsWith(program.basePath))
+    return sourcePath.slice(program.basePath.length);
   else
-    return path;
+    return sourcePath;
 }
 
 var callbacks = undefined

--- a/test/cli.js
+++ b/test/cli.js
@@ -69,9 +69,7 @@ tape('CLI', function (t) {
       './solcjs --bin ' +
         'test/resources/importA.sol ' +
         './test/resources//importA.sol ' +
-        path.resolve('test/resources/importA.sol') + ' ' +
-        // Adding importB explicitly here should make compiler find it despite the lack of callback
-        'test/resources/importB.sol '
+        path.resolve('test/resources/importA.sol')
     );
     spt.stderr.empty();
     spt.succeeds();


### PR DESCRIPTION
This is the solc-js part of https://github.com/ethereum/solidity/issues/11408.

The PR changes the base path stripping logic to more or less match https://github.com/ethereum/solidity/pull/11617 / https://github.com/ethereum/solidity/pull/11545. This is a simplified version so I did not try to get all corner cases right and test coverage is minimal (I can't test it well without access to the JSON input anyway).

I only tested it on Linux. Hopefully CI runs on Windows too.

One extra change is that the PR enables import callback even without `--base-path` option because this is how it works on `solc`. I did not enable it for `--standard-json` because we do not have `--allow-paths` here and therefore the callback could kick in even without the user realizing it.