### PR TITLE
[solcjs] `--pretty-json` and `--verbose` options

### DIFF
--- a/solcjs
+++ b/solcjs
@@ -38,7 +38,8 @@ program
   .option('--abi', 'ABI of the contracts.')
   .option('--standard-json', 'Turn on Standard JSON Input / Output mode.')
   .option('--base-path <path>', 'Automatically resolve all imports inside the given path.')
-  .option('-o, --output-dir <output-directory>', 'Output directory for the contracts.');
+  .option('-o, --output-dir <output-directory>', 'Output directory for the contracts.')
+  .option('-p, --pretty-json', 'Pretty-print all JSON output.', false);
 
 program.parse(process.argv);
 const options = program.opts();
@@ -91,18 +92,26 @@ function stripBasePath(sourcePath) {
   return withUnixPathSeparators(relativeSourcePath);
 }
 
+function toFormattedJson(input) {
+  return JSON.stringify(input, null, program.prettyJson ? 4 : 0);
+}
+
+function reformatJsonIfRequested(inputJson) {
+  return (program.prettyJson ? toFormattedJson(JSON.parse(inputJson)) : inputJson);
+}
+
 var callbacks = undefined
 if (options.basePath || !options.standardJson)
   callbacks = {'import': readFileCallback};
 
 if (options.standardJson) {
   var input = fs.readFileSync(process.stdin.fd).toString('utf8');
-  var output = solc.compile(input, callbacks);
+  var output = reformatJsonIfRequested(solc.compile(input, callbacks));
 
   try {
     var inputJSON = smtchecker.handleSMTQueries(JSON.parse(input), JSON.parse(output), smtsolver.smtSolver);
     if (inputJSON) {
-      output = solc.compile(JSON.stringify(inputJSON), callbacks);
+      output = reformatJsonIfRequested(solc.compile(JSON.stringify(inputJSON), callbacks));
     }
   }
   catch (e) {
@@ -118,7 +127,7 @@ if (options.standardJson) {
       outputJSON.errors = []
     }
     outputJSON.errors.push(addError);
-    output = JSON.stringify(outputJSON);
+    output = toFormattedJson(outputJSON);
   }
 
   console.log(output);
@@ -195,7 +204,7 @@ for (var fileName in output.contracts) {
     }
 
     if (options.abi) {
-      writeFile(contractFileName + '.abi', JSON.stringify(output.contracts[fileName][contractName].abi));
+      writeFile(contractFileName + '.abi', toFormattedJson(output.contracts[fileName][contractName].abi));
     }
   }
 }

--- a/solcjs
+++ b/solcjs
@@ -39,7 +39,8 @@ program
   .option('--standard-json', 'Turn on Standard JSON Input / Output mode.')
   .option('--base-path <path>', 'Automatically resolve all imports inside the given path.')
   .option('-o, --output-dir <output-directory>', 'Output directory for the contracts.')
-  .option('-p, --pretty-json', 'Pretty-print all JSON output.', false);
+  .option('-p, --pretty-json', 'Pretty-print all JSON output.', false)
+  .option('-v, --verbose', 'More detailed console output.', false);
 
 program.parse(process.argv);
 const options = program.opts();
@@ -106,11 +107,15 @@ if (options.basePath || !options.standardJson)
 
 if (options.standardJson) {
   var input = fs.readFileSync(process.stdin.fd).toString('utf8');
+  if (program.verbose)
+    console.log('>>> Compiling:\n' + reformatJsonIfRequested(input) + "\n")
   var output = reformatJsonIfRequested(solc.compile(input, callbacks));
 
   try {
     var inputJSON = smtchecker.handleSMTQueries(JSON.parse(input), JSON.parse(output), smtsolver.smtSolver);
     if (inputJSON) {
+      if (program.verbose)
+        console.log('>>> Retrying compilation with SMT:\n' + toFormattedJson(inputJSON) + "\n")
       output = reformatJsonIfRequested(solc.compile(JSON.stringify(inputJSON), callbacks));
     }
   }
@@ -130,6 +135,8 @@ if (options.standardJson) {
     output = toFormattedJson(outputJSON);
   }
 
+  if (program.verbose)
+    console.log('>>> Compilation result:')
   console.log(output);
   process.exit(0);
 } else if (files.length === 0) {
@@ -151,7 +158,7 @@ for (var i = 0; i < files.length; i++) {
   }
 }
 
-var output = JSON.parse(solc.compile(JSON.stringify({
+const cliInput = {
   language: 'Solidity',
   settings: {
     optimizer: {
@@ -165,7 +172,10 @@ var output = JSON.parse(solc.compile(JSON.stringify({
     }
   },
   sources: sources
-}), callbacks));
+};
+if (program.verbose)
+  console.log('>>> Compiling:\n' + toFormattedJson(cliInput) + "\n")
+var output = JSON.parse(solc.compile(JSON.stringify(cliInput), callbacks));
 
 let hasError = false;
 


### PR DESCRIPTION
Somewhat related to https://github.com/ethereum/solidity/issues/11583.

This PR adds two options
- `--pretty-print` - we already have that in solc and soon it will work for Standard jSON too (https://github.com/ethereum/solidity/pull/11639).
- `--verbose` - prints extra info, most importantly the Standard JSON input to the compiler. It's most useful when not using `--standard-json` option because then it's the script that constructs the input JSON. I wanted to see it pretty much every time I was solving a problem with solc-js and I always ended up hacking it in with debug prints. Having this as an option would make working with solc-js much more convenient for me and I think it might be useful for others too.