### PR TITLE
Remove `npm run prepublishOnly` from `pretest`.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,9 @@ jobs:
           name: install-npm
           command: npm install
       - run:
+          name: updateBinary
+          command: npm run updateBinary
+      - run:
           name: test
           command: npm run test
       - when:

--- a/package.json
+++ b/package.json
@@ -8,8 +8,9 @@
   },
   "scripts": {
     "lint": "node ./node_modules/semistandard/bin/cmd.js",
-    "prepublishOnly": "node downloadCurrentVersion.js && node verifyVersion.js",
-    "pretest": "npm run lint && npm run prepublishOnly",
+    "updateBinary": "node downloadCurrentVersion.js && node verifyVersion.js",
+    "prepublishOnly": "npm run updateBinary",
+    "pretest": "npm run lint && npm run updateBinary",
     "test": "tape ./test/index.js",
     "coverage": "node ./node_modules/nyc/bin/nyc.js --reporter=lcov --reporter=text-summary ./node_modules/tape/bin/tape ./test/index.js",
     "coveralls": "npm run coverage && node ./node_modules/coveralls/bin/coveralls.js <coverage/lcov.info"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "node ./node_modules/semistandard/bin/cmd.js",
     "updateBinary": "node downloadCurrentVersion.js && node verifyVersion.js",
     "prepublishOnly": "npm run updateBinary",
-    "pretest": "npm run lint && npm run updateBinary",
+    "pretest": "npm run lint",
     "test": "tape ./test/index.js",
     "coverage": "node ./node_modules/nyc/bin/nyc.js --reporter=lcov --reporter=text-summary ./node_modules/tape/bin/tape ./test/index.js",
     "coveralls": "npm run coverage && node ./node_modules/coveralls/bin/coveralls.js <coverage/lcov.info"


### PR DESCRIPTION
Leftover in https://github.com/ethereum/solidity/pull/11750 and my guess what currently breaks the solidity tests.