### PR TITLE
[solcjs] `--include-path` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,17 @@ solcjs --help
 
 To compile a contract that imports other contracts via relative paths:
 ```bash
-solcjs --bin --base-path . ./MainContract.sol
+solcjs --bin --include-path node_modules/ --base-path . MainContract.sol
 ```
-The option ``--base-path`` enables automatic loading of imports from the filesystem and
-takes a path as argument that contains the source files.
+Use the ``--base-path`` and ``--include-path`` options to describe the layout of your project.
+``--base-path`` represents the root of your own source tree while ``--include-path`` allows you to
+specify extra locations containing external code (e.g. libraries installed with a package manager).
+
+Note: ensure that all the files you specify on the command line are located inside the base path or
+one of the include paths.
+The compiler refers to files from outside of these directories using absolute paths.
+Having absolute paths in contract metadata will result in your bytecode being reproducible only
+when it's placed in these exact absolute locations.
 
 Note: this commandline interface is not compatible with `solc` provided by the Solidity compiler package and thus cannot be
 used in combination with an Ethereum client via the `eth.compile.solidity()` RPC method. Please refer to the

--- a/solcjs
+++ b/solcjs
@@ -37,7 +37,13 @@ program
   .option('--bin', 'Binary of the contracts in hex.')
   .option('--abi', 'ABI of the contracts.')
   .option('--standard-json', 'Turn on Standard JSON Input / Output mode.')
-  .option('--base-path <path>', 'Automatically resolve all imports inside the given path.')
+  .option('--base-path <path>', 'Root of the project source tree. ' +
+    'The import callback will attempt to interpret all import paths as relative to this directory.'
+  )
+  .option('--include-path <path...>', 'Extra source directories available to the import callback. ' +
+    'When using a package manager to install libraries, use this option to specify directories where packages are installed. ' +
+    'Can be used multiple times to provide multiple locations.'
+  )
   .option('-o, --output-dir <output-directory>', 'Output directory for the contracts.')
   .option('-p, --pretty-json', 'Pretty-print all JSON output.', false)
   .option('-v, --verbose', 'More detailed console output.', false);
@@ -54,16 +60,21 @@ function abort (msg) {
 }
 
 function readFileCallback(sourcePath) {
-  if (options.basePath)
-    sourcePath = options.basePath + '/' + sourcePath;
-  if (fs.existsSync(sourcePath)) {
-    try {
-      return { 'contents': fs.readFileSync(sourcePath).toString('utf8') }
-    } catch (e) {
-      return { error: 'Error reading ' + sourcePath + ': ' + e };
+  const prefixes = [options.basePath ? options.basePath : ""].concat(
+    options.includePath ? options.includePath : []
+  );
+  for (const prefix of prefixes) {
+    const prefixedSourcePath = (prefix ? prefix + '/' : "") + sourcePath;
+
+    if (fs.existsSync(prefixedSourcePath)) {
+      try {
+        return {'contents': fs.readFileSync(prefixedSourcePath).toString('utf8')}
+      } catch (e) {
+        return {error: 'Error reading ' + prefixedSourcePath + ': ' + e};
+      }
     }
-  } else
-    return { error: 'File not found at ' + sourcePath}
+  }
+  return {error: 'File not found inside the base path or any of the include paths.'}
 }
 
 function withUnixPathSeparators(filePath) {
@@ -74,8 +85,13 @@ function withUnixPathSeparators(filePath) {
   return filePath.replace(/\\/g, "/");
 }
 
-function stripBasePath(sourcePath) {
+function makeSourcePathRelativeIfPossible(sourcePath) {
   const absoluteBasePath = (options.basePath ? path.resolve(options.basePath) : path.resolve('.'));
+  const absoluteIncludePaths = (
+    options.includePath ?
+    options.includePath.map((prefix) => { return path.resolve(prefix); }) :
+    []
+  );
 
   // Compared to base path stripping logic in solc this is much simpler because path.resolve()
   // handles symlinks correctly (does not resolve them except in work dir) and strips .. segments
@@ -84,13 +100,16 @@ function stripBasePath(sourcePath) {
   // Windows and UNC paths are not handled in a special way (at least on Linux). Finally, it has
   // very little test coverage so there might be more differences that we are just not aware of.
   const absoluteSourcePath = path.resolve(sourcePath);
-  const relativeSourcePath = path.relative(absoluteBasePath, absoluteSourcePath);
 
-  if (relativeSourcePath.startsWith('../'))
-    // Path can't be made relative without stepping outside of base path so return absolute one.
-    return withUnixPathSeparators(absoluteSourcePath);
+  for (const absolutePrefix of [absoluteBasePath].concat(absoluteIncludePaths)) {
+    const relativeSourcePath = path.relative(absolutePrefix, absoluteSourcePath);
 
-  return withUnixPathSeparators(relativeSourcePath);
+    if (!relativeSourcePath.startsWith('../'))
+      return withUnixPathSeparators(relativeSourcePath);
+  }
+
+  // File is not located inside base path or include paths so use its absolute path.
+  return withUnixPathSeparators(absoluteSourcePath);
 }
 
 function toFormattedJson(input) {
@@ -148,11 +167,22 @@ if (!(options.bin || options.abi)) {
   abort('Invalid option selected, must specify either --bin or --abi');
 }
 
+if (!options.basePath && options.includePath && options.includePath.length > 0) {
+  abort('--include-path option requires a non-empty base path.');
+}
+
+if (options.includePath)
+  for (const includePath of options.includePath)
+    if (!includePath)
+      abort('Empty values are not allowed in --include-path.');
+
 var sources = {};
 
 for (var i = 0; i < files.length; i++) {
   try {
-    sources[stripBasePath(files[i])] = { content: fs.readFileSync(files[i]).toString() };
+    sources[makeSourcePathRelativeIfPossible(files[i])] = {
+      content: fs.readFileSync(files[i]).toString()
+    };
   } catch (e) {
     abort('Error reading ' + files[i] + ': ' + e);
   }

--- a/test/resources/importCallback/base/contractA.sol
+++ b/test/resources/importCallback/base/contractA.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.0;
+
+import "libX.sol";
+import "libY.sol";
+import "libZ.sol";
+
+contract A {}

--- a/test/resources/importCallback/base/contractB.sol
+++ b/test/resources/importCallback/base/contractB.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.0;
+
+import "./contractA.sol";
+
+contract B {}

--- a/test/resources/importCallback/contractC.sol
+++ b/test/resources/importCallback/contractC.sol
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.0;
+
+contract C {}

--- a/test/resources/importCallback/includeA/libX.sol
+++ b/test/resources/importCallback/includeA/libX.sol
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.0;
+
+library X {}

--- a/test/resources/importCallback/includeA/libY.sol
+++ b/test/resources/importCallback/includeA/libY.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.0;
+
+import "./utils.sol";
+
+library Y {}

--- a/test/resources/importCallback/includeA/utils.sol
+++ b/test/resources/importCallback/includeA/utils.sol
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.0;
+
+library Utils {}

--- a/test/resources/importCallback/includeB/libZ.sol
+++ b/test/resources/importCallback/includeB/libZ.sol
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.0;
+
+library Z {}


### PR DESCRIPTION
Implements the `solc-js` part of https://github.com/ethereum/solidity/pull/11848.
Depends on #547.

The implementation is simplified compared to `solc` and argument processing from the `commander` works a bit differently than in `boost::program_options`:
- There's no check against path conflicts (two files specified on the CLI getting the same source unit name after base path/include path stripping).
- There's no check against ambiguous imports (one import matching multiple files in base path/include paths).
- `commander` allows specifying multiple paths while using the option only once `--include-path path1/ path2/ path3/`. This is a bit inconvenient because if it's the last option, it consumes the names of the input files. E.g. `solcjs --base-path base/ --include-paths node_modules/ MyContract.sol` will treat `MyContract.sol` as one of the include paths. The library does not allow disabling this behavior.
    - The boost syntax with option used multiple times works too: `--include-path path1/ --include-path  path2/ --include-path  path3/`