### PR TITLE
CI run for nodejs v17

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ workflows:
           run_coveralls: true
       - node-v14
       - node-v16
+      - node-v17
 
 version: 2.1
 jobs:
@@ -74,3 +75,7 @@ jobs:
     <<: *node-base
     docker:
       - image: circleci/node:16
+  node-v17:
+    <<: *node-base
+    docker:
+      - image: circleci/node:17

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,10 +4,10 @@ workflows:
     jobs:
       - node-v8
       - node-v10
-      - node-v12:
-          run_coveralls: true
+      - node-v12
       - node-v14
-      - node-v16
+      - node-v16:
+          run_coveralls: true
       - node-v17
 
 version: 2.1


### PR DESCRIPTION
Nodejs v17 is out now and people will probably want to use it. I know that some frameworks do not support it yet (Hardhat does not, not sure about Truffle) but solc-js does seem to work so would not hurt to have a CI run for it, at least until v18 is released.

Also, not sure why coveralls is still on v12 but seems to work fine with v16. Not sure if it's worth putting it on v17 already though.