### PR TITLE
Remove the workaround for greedy exception catcher

### DIFF
--- a/solcjs
+++ b/solcjs
@@ -1,17 +1,11 @@
 #!/usr/bin/env node
 
-// hold on to any exception handlers that existed prior to this script running, we'll be adding them back at the end
-var originalUncaughtExceptionListeners = process.listeners("uncaughtException");
-
 var fs = require('fs-extra');
 var os = require('os');
 var path = require('path');
 var solc = require('./index.js');
 var smtchecker = require('./smtchecker.js');
 var smtsolver = require('./smtsolver.js');
-// FIXME: remove annoying exception catcher of Emscripten
-//        see https://github.com/chriseth/browser-solidity/issues/167
-process.removeAllListeners('uncaughtException');
 var commander = require('commander');
 
 const program = new commander.Command();
@@ -248,11 +242,6 @@ for (var fileName in output.contracts) {
     }
   }
 }
-
-// Put back original exception handlers.
-originalUncaughtExceptionListeners.forEach(function (listener) {
-  process.addListener('uncaughtException', listener);
-});
 
 if (hasError) {
   process.exit(1);


### PR DESCRIPTION
This PR removes the old workaround that was added in #34 to solve https://github.com/chriseth/browser-solidity/issues/167.

The issue was solved properly by adding `NODEJS_CATCH_EXIT=0` flag to our emscripten build in 0.4.20 (https://github.com/ethereum/solidity/pull/3477). According to https://github.com/ethereum/solc-js/issues/174#issuecomment-358016947 the workaround is no longer needed.