### PR TITLE
Removes dependency on fs-extra.

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "command-exists": "^1.2.8",
     "commander": "^8.1.0",
     "follow-redirects": "^1.12.1",
-    "fs-extra": "^0.30.0",
     "js-sha3": "0.8.0",
     "memorystream": "^0.3.1",
     "require-from-string": "^2.0.0",

--- a/solcjs
+++ b/solcjs
@@ -3,7 +3,7 @@
 // hold on to any exception handlers that existed prior to this script running, we'll be adding them back at the end
 var originalUncaughtExceptionListeners = process.listeners("uncaughtException");
 
-var fs = require('fs-extra');
+var fs = require('fs');
 var os = require('os');
 var path = require('path');
 var solc = require('./index.js');
@@ -223,7 +223,7 @@ if (!output) {
   }
 }
 
-fs.ensureDirSync (destination);
+fs.mkdirSync(destination, { mode: 0o777, recursive: true });
 
 function writeFile (file, content) {
   file = path.join(destination, file);


### PR DESCRIPTION
This should remove ~16 of the 25 dependencies of this project, which reduces the attack surface area and gets us down to only direct dependencies I believe.

See https://github.com/ethereum/solc-js/issues/361#issuecomment-993230407 for additional discussion.

I went ahead and removed the path check per thought from @chriseth, but I'm happy to put it back in if desired.