### PR TITLE
Drop require-from-string to restore Webpack compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "follow-redirects": "^1.12.1",
     "js-sha3": "0.8.0",
     "memorystream": "^0.3.1",
-    "require-from-string": "^2.0.0",
     "semver": "^5.5.0",
     "tmp": "0.0.33"
   },

--- a/wrapper.js
+++ b/wrapper.js
@@ -1,6 +1,6 @@
 const assert = require('assert');
 const translate = require('./translate.js');
-const requireFromString = require('require-from-string');
+const Module = require('module');
 const https = require('follow-redirects').https;
 const MemoryStream = require('memorystream');
 const semver = require('semver');
@@ -335,7 +335,16 @@ function setupMethods (soljson) {
         } else {
           response.pipe(mem);
           response.on('end', function () {
-            cb(null, setupMethods(requireFromString(mem.toString(), 'soljson-' + versionString + '.js')));
+            // Based on the require-from-string package.
+            const soljson = new Module();
+            soljson._compile(mem.toString(), 'soljson-' + versionString + '.js');
+            if (module.parent && module.parent.children) {
+              // Make sure the module is plugged into the hierarchy correctly to have parent
+              // properly garbage collected.
+              module.parent.children.splice(module.parent.children.indexOf(soljson), 1);
+            }
+
+            cb(null, setupMethods(soljson.exports));
           });
         }
       }).on('error', function (error) {

--- a/wrapper.js
+++ b/wrapper.js
@@ -1,6 +1,6 @@
 const assert = require('assert');
 const translate = require('./translate.js');
-const Module = require('module');
+const Module = module.constructor;
 const https = require('follow-redirects').https;
 const MemoryStream = require('memorystream');
 const semver = require('semver');


### PR DESCRIPTION
Fixes #576.

`require-from-string` is a tiny package and we're even not using all of its features. It's also no longer maintained because https://github.com/floatdrop/require-from-string/issues/18 is has not been fixed since 2018. This PR replaces it with a few lines of code and drops the dependency.

The real question is how do we test this properly? It passes our current tests but the problem exists only on Webpack.

Also, the author or the PR that broke Webpack compatibility claims that Webpack does not even provide `module` (https://github.com/floatdrop/require-from-string/pull/6#issuecomment-369216332). Not sure how to verify that.