### PR TITLE
Add a wrapper script to keep `./solcjs` working

### DIFF
--- a/solcjs
+++ b/solcjs
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+
+# Wrapper script for backwards compatibility with the old repo structure.
+#
+# NOTE: It's recommended to run `npx solcjs` instead if you're installing solc-js as an npm package.
+# Or, if you're using the repository directly, you should switch to `dist/solc.js`.
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+cd "$script_dir"
+
+[ -e dist/solc.js ] || npm run build
+exec dist/solc.js "$@" < /dev/stdin


### PR DESCRIPTION
After #587 anything that relies on executing specifically `./solcjs` is broken. For example in the main repo external tests (e.g. the [Colony test](https://app.circleci.com/pipelines/github/ethereum/solidity/21783/workflows/aefcceb6-82c0-419f-a3d8-f66785920024/jobs/954433)) are failing due to this.

The right solution is to run `solcjs` via `npm exec` but I think this is might still break some workflows and we should wait with it until a breaking release. This is expecially because apparently the file in `node_modules/.bin/` does not get created when you clone the repo and run `npm install` so `npm exec` is unusable in that scenario. I suspect the file in `node_modules/.bin/` might only be created for packages installed as dependencies.