### PR TITLE
Fix: Ensure that tests work even if /tmp is not accessible

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   },
   "devDependencies": {
     "@types/node": "^16.11.7",
+    "@types/tmp": "^0.2.3",
     "@types/semver": "^7.3.9",
     "@types/tape": "^4.13.2",
     "@typescript-eslint/eslint-plugin": "^5.8.0",

--- a/test/compiler.ts
+++ b/test/compiler.ts
@@ -1,6 +1,7 @@
 import assert from 'assert';
 import tape from 'tape';
 import * as semver from 'semver';
+import * as tmp from 'tmp';
 import solc from '../';
 import linker from '../linker';
 import { execSync } from 'child_process';
@@ -888,8 +889,10 @@ if (!noRemoteVersions) {
   ];
   for (let version in versions) {
     version = versions[version];
-    execSync(`curl -L -o /tmp/${version}.js https://binaries.soliditylang.org/bin/soljson-${version}.js`);
-    const newSolc = wrapper(require(`/tmp/${version}.js`));
+    // NOTE: The temporary directory will be removed on process exit.
+    const tempDir = tmp.dirSync({ unsafeCleanup: true, prefix: 'solc-js-compiler-test-' }).name;
+    execSync(`curl -L -o ${tempDir}/${version}.js https://binaries.soliditylang.org/bin/soljson-${version}.js`);
+    const newSolc = wrapper(require(`${tempDir}/${version}.js`));
     runTests(newSolc, version);
   }
 }


### PR DESCRIPTION
Fixes #588.

- [x] Created a temporary directory using `tmp` package inside function `createTempDir()`
- [x] Returned the name of temporary directory from the function `createTempDir()`
- [x] Replaced `/tmp` with name of created temporary directory `tempDir`
