### PR TITLE
Fix the import of `tmp` in `smtsolver.ts`

### DIFF
--- a/smtsolver.ts
+++ b/smtsolver.ts
@@ -1,7 +1,7 @@
 import { sync as commandExistsSync } from 'command-exists';
 import { execSync } from 'child_process';
 import * as fs from 'fs';
-import tmp from 'tmp';
+import * as tmp from 'tmp';
 
 // Timeout in ms.
 const timeout = 10000;


### PR DESCRIPTION
Looks like `tmp` is not being imported incorrectly. Not sure how that passed tests in #566 but tests are failing due to this in the main repo (https://github.com/ethereum/solidity/pull/12583).
```
TypeError: Cannot read property 'fileSync' of undefined
```

In addition to merging this, we should really investigate why it passed our CI.

### Steps to reproduce
```
git clone https://github.com/ethereum/solc-js/
cd solc-js/
npm install
npm run updateBinary
npm run test
```
```
# SMTCheckerWithSolver
# Simple test with axuiliaryInputRequested
ok 1108 should be truthy
/tmp/v0.1.1+commit.6ff4cd6.js:84
      throw ex;
      ^

TypeError: Cannot read property 'fileSync' of undefined
    at solve (/tmp/d/solc-js/dist/smtsolver.js:36:35)
    at Object.handleSMTQueries (/tmp/d/solc-js/dist/smtchecker.js:19:28)
    at Test.<anonymous> (/tmp/d/solc-js/dist/test/smtchecker.js:78:47)
    at Test.bound [as _cb] (/tmp/d/solc-js/node_modules/tape/lib/test.js:88:32)
    at Test.run (/tmp/d/solc-js/node_modules/tape/lib/test.js:105:10)
    at Test.bound [as run] (/tmp/d/solc-js/node_modules/tape/lib/test.js:88:32)
    at Test._end (/tmp/d/solc-js/node_modules/tape/lib/test.js:181:11)
    at Test.bound [as _end] (/tmp/d/solc-js/node_modules/tape/lib/test.js:88:32)
    at Immediate.<anonymous> (/tmp/d/solc-js/node_modules/tape/lib/test.js:127:18)
    at processImmediate (internal/timers.js:461:21)
```