### PR TITLE
fix: export all properties under the root instead of default

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,26 @@
 import wrapper from './wrapper';
 
 const soljson = require('./soljson.js');
+const wrapped = wrapper(soljson);
 
-export default wrapper(soljson);
+const {
+  version,
+  semver,
+  license,
+  lowlevel,
+  features,
+  compile,
+  loadRemoteVersion,
+  setupMethods
+} = wrapped;
+
+export {
+  version,
+  semver,
+  license,
+  lowlevel,
+  features,
+  compile,
+  loadRemoteVersion,
+  setupMethods
+};

--- a/solc.ts
+++ b/solc.ts
@@ -4,7 +4,7 @@ import * as commander from 'commander';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import solc from './index';
+import * as solc from './index';
 import smtchecker from './smtchecker';
 import smtsolver from './smtsolver';
 

--- a/test/compiler.ts
+++ b/test/compiler.ts
@@ -1,7 +1,7 @@
 import * as assert from 'assert';
 import * as tape from 'tape';
 import * as semver from 'semver';
-import solc from '../';
+import * as solc from '../';
 import linker from '../linker';
 import { execSync } from 'child_process';
 import wrapper from '../wrapper';

--- a/test/smtcallback.ts
+++ b/test/smtcallback.ts
@@ -3,7 +3,7 @@ import * as tape from 'tape';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as semver from 'semver';
-import solc from '../';
+import * as solc from '../';
 import smtchecker from '../smtchecker';
 import smtsolver from '../smtsolver';
 

--- a/test/smtchecker.ts
+++ b/test/smtchecker.ts
@@ -1,6 +1,6 @@
 import * as tape from 'tape';
 import * as semver from 'semver';
-import solc from '../';
+import * as solc from '../';
 import smtchecker from '../smtchecker';
 import smtsolver from '../smtsolver';
 

--- a/verifyVersion.ts
+++ b/verifyVersion.ts
@@ -3,7 +3,7 @@
 import * as semver from 'semver';
 
 import { version as packageVersion } from './package.json';
-import solc from './';
+import * as solc from './';
 
 const solcVersion = (solc as any).version();
 


### PR DESCRIPTION
By exporting under the root, javascript importing modules will continue
to use it as expected without first having to index `.default.`