### PR TITLE
CI tests based on Truffle and Hardhat

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,12 @@ workflows:
 version: 2.1
 
 commands:
+  show-npm-version:
+    steps:
+      - run:
+          name: Versions
+          command: npm version
+
   install-dependencies:
     parameters:
       cache-id:
@@ -48,9 +54,7 @@ jobs:
         type: boolean
         default: false
     steps:
-      - run:
-          name: Versions
-          command: npm version
+      - show-npm-version
       - checkout
       - install-dependencies:
           cache-id: solc-js

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,34 @@ workflows:
       - node-v17
 
 version: 2.1
+
+commands:
+  install-dependencies:
+    parameters:
+      cache-id:
+        type: string
+      path:
+        type: string
+        default: .
+      package-manager:
+        type: string
+        default: npm
+      dependency-file:
+        type: string
+        default: package.json
+    steps:
+      - restore_cache:
+          key: <<parameters.cache-id>>-dependency-cache-v2-{{ .Environment.CIRCLE_JOB }}-{{ checksum "<<parameters.path>>/<<parameters.dependency-file>>" }}
+      - run:
+          name: "<<parameters.package-manager>> install in <<parameters.path>>"
+          command: |
+            cd "<<parameters.path>>"
+            [[ -e node_modules/ ]] || <<parameters.package-manager>> install
+      - save_cache:
+          key: <<parameters.cache-id>>-dependency-cache-v2-{{ .Environment.CIRCLE_JOB }}-{{ checksum "<<parameters.path>>/<<parameters.dependency-file>>" }}
+          paths:
+            - "<<parameters.path>>/node_modules/"
+
 jobs:
   node-base: &node-base
     working_directory: ~/solc-js
@@ -24,8 +52,8 @@ jobs:
           name: Versions
           command: npm version
       - checkout
-      - restore_cache:
-          key: dependency-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package.json" }}
+      - install-dependencies:
+          cache-id: solc-js
       - run:
           name: install-npm
           command: npm install
@@ -41,10 +69,6 @@ jobs:
             - run:
                 name: coveralls
                 command: npm run coveralls
-      - save_cache:
-          key: dependency-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package.json" }}
-          paths:
-            - ./node_modules
 
   node-v10:
     <<: *node-base

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,10 @@ workflows:
       - node-v16:
           run_coveralls: true
       - node-v17
+      - hardhat-core-default-solc
+      - hardhat-core-latest-solc
+      - hardhat-sample-project
+      - truffle-sample-project
 
 version: 2.1
 
@@ -44,6 +48,96 @@ commands:
           paths:
             - "<<parameters.path>>/node_modules/"
 
+  install-truffle-dependencies:
+    steps:
+      - run:
+          name: Store current Truffle commit ID in a variable
+          command: |
+            cd truffle/
+            echo "export _TRUFFLE_COMMIT_ID=$(git rev-parse --verify HEAD)" >> $BASH_ENV
+      - restore_cache:
+          key: truffle-dependency-cache-{{ checksum "truffle/yarn.lock" }}-{{ .Environment._TRUFFLE_COMMIT_ID }}
+      - run:
+          name: yarn install in truffle
+          command: |
+            cd truffle/
+            [[ -e node_modules/ ]] || yarn install
+      - save_cache:
+          key: truffle-dependency-cache-{{ checksum "truffle/yarn.lock" }}-{{ .Environment._TRUFFLE_COMMIT_ID }}
+          paths:
+            - truffle/
+
+  inject-solc-js-tarball:
+    description: "Recursively finds and replaces all instances of solc-js module installed in node_modules/ with the one from a tarball."
+    parameters:
+      path:
+        type: string
+        default: .
+      tarball-path:
+        type: string
+        default: solc-js.tgz
+      install-command:
+        type: string
+        default: npm install
+    steps:
+      - run:
+          name: Inject solc-js from the tarball into dependencies at <<parameters.path>>
+          command: |
+            [[ -f "<<parameters.tarball-path>>" ]]
+            absolute_tarball_path=$(realpath "<<parameters.tarball-path>>")
+            for solc_module in $(find "<<parameters.path>>" -type d -path "*/node_modules/solc"); do
+                pushd "${solc_module}/../.."
+                <<parameters.install-command>> "$absolute_tarball_path" --ignore-workspace-root-check
+                popd
+            done
+
+  provision-and-package-solcjs:
+    description: "Creates a package out of latest solc-js to test its installation as a dependency."
+    steps:
+      - checkout:
+          path: solc-js/
+      - install-dependencies:
+          cache-id: solc-js
+          path: solc-js
+      - run:
+          name: Package solc-js
+          command: |
+            cd solc-js/
+            npm run build:tarball
+            mv "$(npm run --silent tarballName)" ../solc-js.tgz
+
+  provision-hardhat-with-packaged-solcjs:
+    description: "Clones Hardhat repository and configures it to use a local clone of solc-js."
+    steps:
+      - run: git clone --depth 1 "https://github.com/nomiclabs/hardhat" hardhat/
+      - install-dependencies:
+          cache-id: hardhat
+          path: hardhat
+          package-manager: yarn
+          dependency-file: yarn.lock
+      - inject-solc-js-tarball:
+          path: hardhat/
+          install-command: yarn add
+
+  provision-truffle-with-packaged-solcjs:
+    description: "Clones Truffle repository and configures it to use a local clone of solc-js."
+    steps:
+      - run: git clone --depth 1 "https://github.com/trufflesuite/truffle" truffle/
+      - install-truffle-dependencies
+      - inject-solc-js-tarball:
+          path: truffle/node_modules/
+          install-command: yarn add
+      - run:
+          name: Neutralize any copies of solc-js outside of node_modules/
+          command: |
+            # NOTE: Injecting solc-js into node_modules/ dirs located under truffle/packages/ causes
+            # an error 'Tarball is not in network and can not be located in cache'. These are not
+            # supposed to be used but let's remove them just in case.
+            find truffle/ \
+              -path "*/solc/wrapper.js" \
+              -not -path "truffle/node_modules/*" \
+              -printf "%h\n" | xargs --verbose rm -r
+
 jobs:
   node-base: &node-base
     working_directory: ~/solc-js
@@ -73,6 +167,119 @@ jobs:
             - run:
                 name: coveralls
                 command: npm run coveralls
+
+  hardhat-core-default-solc:
+    docker:
+      - image: circleci/node:16
+    steps:
+      - show-npm-version
+      - provision-and-package-solcjs
+      - provision-hardhat-with-packaged-solcjs
+      - run:
+          name: Run hardhat-core test suite with its default solc
+          command: |
+            cd hardhat/packages/hardhat-core
+            yarn test
+
+  hardhat-core-latest-solc:
+    docker:
+      - image: circleci/node:16
+    steps:
+      - show-npm-version
+      - provision-and-package-solcjs
+      - provision-hardhat-with-packaged-solcjs
+      - run:
+          name: Run hardhat-core test suite with latest solc
+          command: |
+            HARDHAT_TESTS_SOLC_PATH="${PWD}/solc-js/soljson.js"
+            HARDHAT_TESTS_SOLC_VERSION=$(jq --raw-output .version solc-js/package.json)
+            export HARDHAT_TESTS_SOLC_PATH HARDHAT_TESTS_SOLC_VERSION
+
+            cd hardhat/packages/hardhat-core
+            yarn test
+
+  hardhat-sample-project:
+    docker:
+      - image: circleci/node:16
+    steps:
+      - show-npm-version
+      - provision-and-package-solcjs
+      - run: git clone --depth 1 "https://github.com/nomiclabs/hardhat-hackathon-boilerplate" boilerplate/
+      - run:
+          # Leaving package-lock.json causes a weird error in arborist when npm is used again after
+          # `npm install`: 'The "from" argument must be of type string. Received undefined'
+          name: Neutralize package-lock.json
+          command: rm boilerplate/package-lock.json
+      - install-dependencies:
+          cache-id: hardhat-hackathon-boilerplate
+          path: boilerplate
+      - run:
+          name: Update to the latest Hardhat release
+          command: |
+            # We can just use a release here because injection does not require rebuilding it.
+            cd boilerplate/
+            npm update hardhat
+      - inject-solc-js-tarball:
+          path: boilerplate/
+      - run:
+          name: Configure the boilerplate project to force Hardhat not to use a native binary
+          command: |
+            solc_version=$(jq --raw-output .version solc-js/package.json)
+
+            cd boilerplate/
+
+            sed -i 's|pragma solidity [^;]\+;|pragma solidity *;|g' contracts/Token.sol
+
+            {
+              echo "const {TASK_COMPILE_SOLIDITY_GET_SOLC_BUILD} = require('hardhat/builtin-tasks/task-names');"
+              echo "const assert = require('assert');"
+              echo
+              echo "subtask(TASK_COMPILE_SOLIDITY_GET_SOLC_BUILD, async (args, hre, runSuper) => {"
+              echo "    assert(args.solcVersion == '${solc_version}', 'Unexpected solc version: ' + args.solcVersion);"
+              echo "    return {"
+              echo "        compilerPath: '$(realpath "../solc-js/soljson.js")',"
+              echo "        isSolcJs: true,"
+              echo "        version: args.solcVersion,"
+              echo "        longVersion: args.solcVersion"
+              echo "    };"
+              echo "})"
+              echo "module.exports = {solidity: '${solc_version}'};"
+            } >> hardhat.config.js
+      - run:
+          name: Build and test the boilerplate project with local Hardhat
+          command: |
+            cd boilerplate/
+            npm run test
+
+  truffle-sample-project:
+    docker:
+      - image: circleci/node:12
+    steps:
+      - show-npm-version
+      - provision-and-package-solcjs
+      - provision-truffle-with-packaged-solcjs
+      - run:
+          name: Unbox MetaCoin
+          command: |
+            mkdir metacoin/
+            cd metacoin/
+            node ../truffle/node_modules/.bin/truffle unbox metacoin
+      - run:
+          name: Strip version pragmas
+          command: sed -i 's|pragma solidity [^;]\+;|pragma solidity *;|g' $(find metacoin/{contracts,test}/ -name "*.sol")
+      - run:
+          name: Build and test the sample project with local Truffle and its default solc
+          command: |
+            cd metacoin/
+            node ../truffle/node_modules/.bin/truffle test
+      - run:
+          name: Build and test the sample project with local Truffle and latest solc
+          command: |
+            cd metacoin/
+            # `truffle test` compiles the project but artifacts go into /tmp/
+            ! [[ -e build/ ]] || false
+            echo "module.exports['compilers'] = {solc: {version: '$(realpath node_modules/solc/)'}}" > truffle-config.js
+            node ../truffle/node_modules/.bin/truffle test
 
   node-v10:
     <<: *node-base


### PR DESCRIPTION
~Depends on #596. Should not be merged before that PR.~ Merged.

This PR adds CI jobs that run latest Truffle and Hardhat with injected solc-js. This runs their test suites and also tries to compile a sample project.