### PR TITLE
fix: use esModuleInterop to resolve commonjs default require

### DIFF
--- a/abi.ts
+++ b/abi.ts
@@ -58,6 +58,6 @@ function update (compilerVersion, abi) {
   return abi;
 }
 
-export default {
+export = {
   update
 };

--- a/downloadCurrentVersion.ts
+++ b/downloadCurrentVersion.ts
@@ -3,11 +3,11 @@
 // This is used to download the correct binary version
 // as part of the prepublish step.
 
-import * as pkg from './package.json';
 import * as fs from 'fs';
 import { https } from 'follow-redirects';
-import * as MemoryStream from 'memorystream';
+import MemoryStream from 'memorystream';
 import { keccak256 } from 'js-sha3';
+const pkg = require('./package.json');
 
 function getVersionList (cb) {
   console.log('Retrieving available version list...');

--- a/index.ts
+++ b/index.ts
@@ -1,26 +1,4 @@
 import wrapper from './wrapper';
 
 const soljson = require('./soljson.js');
-const wrapped = wrapper(soljson);
-
-const {
-  version,
-  semver,
-  license,
-  lowlevel,
-  features,
-  compile,
-  loadRemoteVersion,
-  setupMethods
-} = wrapped;
-
-export {
-  version,
-  semver,
-  license,
-  lowlevel,
-  features,
-  compile,
-  loadRemoteVersion,
-  setupMethods
-};
+export = wrapper(soljson);

--- a/linker.ts
+++ b/linker.ts
@@ -1,4 +1,4 @@
-import * as assert from 'assert';
+import assert from 'assert';
 import { keccak256 } from 'js-sha3';
 
 function libraryHashPlaceholder (input) {
@@ -88,7 +88,7 @@ const findLinkReferences = function (bytecode) {
   return linkReferences;
 };
 
-export default {
+export = {
   linkBytecode,
   findLinkReferences
 };

--- a/smtchecker.ts
+++ b/smtchecker.ts
@@ -36,7 +36,7 @@ function smtCallback (solverFunction, solver?: any) {
   };
 }
 
-export default {
+export = {
   handleSMTQueries,
   smtCallback
 };

--- a/smtsolver.ts
+++ b/smtsolver.ts
@@ -67,7 +67,7 @@ function solve (query, solver) {
   return solverOutput;
 }
 
-export default {
+export = {
   smtSolver: solve,
   availableSolvers: solvers
 };

--- a/solc.ts
+++ b/solc.ts
@@ -4,7 +4,7 @@ import * as commander from 'commander';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import * as solc from './index';
+import solc from './index';
 import smtchecker from './smtchecker';
 import smtsolver from './smtsolver';
 

--- a/test/abi.ts
+++ b/test/abi.ts
@@ -1,4 +1,4 @@
-import * as tape from 'tape';
+import tape from 'tape';
 import abi from '../abi';
 
 tape('ABI translator', function (t) {

--- a/test/cli.ts
+++ b/test/cli.ts
@@ -1,7 +1,7 @@
-import * as tape from 'tape';
-import * as spawn from 'tape-spawn';
+import tape from 'tape';
+import spawn from 'tape-spawn';
 import * as path from 'path';
-import * as pkg from '../package.json';
+const pkg = require('../package.json');
 
 tape('CLI', function (t) {
   t.test('--version', function (st) {

--- a/test/compiler.ts
+++ b/test/compiler.ts
@@ -1,7 +1,7 @@
-import * as assert from 'assert';
-import * as tape from 'tape';
+import assert from 'assert';
+import tape from 'tape';
 import * as semver from 'semver';
-import * as solc from '../';
+import solc from '../';
 import linker from '../linker';
 import { execSync } from 'child_process';
 import wrapper from '../wrapper';

--- a/test/linker.ts
+++ b/test/linker.ts
@@ -1,4 +1,4 @@
-import * as tape from 'tape';
+import tape from 'tape';
 import linker from '../linker';
 
 tape('Link references', function (t) {

--- a/test/smtcallback.ts
+++ b/test/smtcallback.ts
@@ -1,9 +1,9 @@
-import * as assert from 'assert';
-import * as tape from 'tape';
+import assert from 'assert';
+import tape from 'tape';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as semver from 'semver';
-import * as solc from '../';
+import solc from '../';
 import smtchecker from '../smtchecker';
 import smtsolver from '../smtsolver';
 

--- a/test/smtchecker.ts
+++ b/test/smtchecker.ts
@@ -1,6 +1,6 @@
-import * as tape from 'tape';
+import tape from 'tape';
 import * as semver from 'semver';
-import * as solc from '../';
+import solc from '../';
 import smtchecker from '../smtchecker';
 import smtsolver from '../smtsolver';
 

--- a/test/translate.ts
+++ b/test/translate.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import * as tape from 'tape';
+import tape from 'tape';
 import translate from '../translate';
 
 const versionToSemver = translate.versionToSemver;

--- a/translate.ts
+++ b/translate.ts
@@ -193,7 +193,7 @@ function prettyPrintLegacyAssemblyJSON (assembly, source) {
   return formatAssemblyText(assembly, '', source);
 }
 
-export default {
+export = {
   versionToSemver,
   translateJsonCompilerOutput,
   prettyPrintLegacyAssemblyJSON

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,10 @@
     "target": "esnext",
     "module": "commonjs",
     "resolveJsonModule": true,
+    // This is needed for backwards-compatibility, to keep imports of the form `wrapper = require('solc/wrapper)`
+    // working like they did before the TypeScript migration.
+    // TODO: Drop it in the next breaking release.
+    "esModuleInterop": true,
     "outDir": "./dist",
     "forceConsistentCasingInFileNames": true,
     // Allow JS must be included to ensure that the built binary is included

--- a/verifyVersion.ts
+++ b/verifyVersion.ts
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 
 import * as semver from 'semver';
+import solc from './';
 
-import { version as packageVersion } from './package.json';
-import * as solc from './';
+const { version: packageVersion } = require('./package.json');
 
 const solcVersion = (solc as any).version();
 

--- a/wrapper.ts
+++ b/wrapper.ts
@@ -1,7 +1,7 @@
 import translate from './translate';
 import { https } from 'follow-redirects';
-import * as MemoryStream from 'memorystream';
-import * as assert from 'assert';
+import MemoryStream from 'memorystream';
+import assert from 'assert';
 import * as semver from 'semver';
 
 const Module = module.constructor as any;
@@ -357,4 +357,4 @@ function setupMethods (soljson) {
   };
 }
 
-export default setupMethods;
+export = setupMethods;


### PR DESCRIPTION
By doing so allows the commonjs default imports to work as expected not blocking
backwards compatibility.

reference: https://www.typescriptlang.org/tsconfig#esModuleInterop

This will stop imports like the following from being a issue.

```js
const wrapper = require('solc/wrapper).default;
```

they will now work as expected as

```js
const wrapper = require('solc/wrapper);
```