### PR TITLE
fix: use npm run publish to release the dist folder directly

### DIFF
--- a/abi.ts
+++ b/abi.ts
@@ -58,6 +58,6 @@ function update (compilerVersion, abi) {
   return abi;
 }
 
-export default {
+export = {
   update
 };

--- a/build/pack-publish-block.js
+++ b/build/pack-publish-block.js
@@ -1,0 +1,9 @@
+// This is meant to run in a hook before npm pack.
+// Reporting an error from the hook interrupts the command.
+if (process.env.BYPASS_SAFETY_CHECK === 'false' || process.env.BYPASS_SAFETY_CHECK === undefined) {
+  console.error('Run `npm run build:tarball` or `npm run publish:tarball` to pack or publish the package');
+  process.exit(1);
+} else if (process.env.BYPASS_SAFETY_CHECK !== 'true') {
+  console.error('Invalid value of the BYPASS_SAFETY_CHECK variable. Must be "true", "false" or unset.');
+  process.exit(1);
+}

--- a/downloadCurrentVersion.ts
+++ b/downloadCurrentVersion.ts
@@ -3,11 +3,11 @@
 // This is used to download the correct binary version
 // as part of the prepublish step.
 
-import * as pkg from './package.json';
 import * as fs from 'fs';
 import { https } from 'follow-redirects';
-import * as MemoryStream from 'memorystream';
+import MemoryStream from 'memorystream';
 import { keccak256 } from 'js-sha3';
+const pkg = require('./package.json');
 
 function getVersionList (cb) {
   console.log('Retrieving available version list...');

--- a/index.ts
+++ b/index.ts
@@ -1,26 +1,4 @@
 import wrapper from './wrapper';
 
 const soljson = require('./soljson.js');
-const wrapped = wrapper(soljson);
-
-const {
-  version,
-  semver,
-  license,
-  lowlevel,
-  features,
-  compile,
-  loadRemoteVersion,
-  setupMethods
-} = wrapped;
-
-export {
-  version,
-  semver,
-  license,
-  lowlevel,
-  features,
-  compile,
-  loadRemoteVersion,
-  setupMethods
-};
+export = wrapper(soljson);

--- a/linker.ts
+++ b/linker.ts
@@ -1,4 +1,4 @@
-import * as assert from 'assert';
+import assert from 'assert';
 import { keccak256 } from 'js-sha3';
 
 function libraryHashPlaceholder (input) {
@@ -88,7 +88,7 @@ const findLinkReferences = function (bytecode) {
   return linkReferences;
 };
 
-export default {
+export = {
   linkBytecode,
   findLinkReferences
 };

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "solc",
   "version": "0.8.11",
   "description": "Solidity compiler",
-  "main": "dist/index.js",
+  "main": "index.js",
   "bin": {
-    "solcjs": "dist/solc.js"
+    "solcjs": "solc.js"
   },
   "scripts": {
     "build": "tsc",
@@ -12,7 +12,10 @@
     "lint": "eslint --ext .js,.ts .",
     "lint:fix": "eslint --fix --ext .js,.ts .",
     "updateBinary": "node build/clean.js && ts-node ./downloadCurrentVersion.ts && ts-node ./verifyVersion.ts",
-    "prepublishOnly": "npm run updateBinary npm && npm run build",
+    "prepack": "node build/pack-publish-block.js",
+    "build:tarball": "npm run updateBinary && npm run build && BYPASS_SAFETY_CHECK=true npm pack ./dist",
+    "publish:tarball": "tarball=$(npm run --silent tarballName) && ls \"$tarball\" && BYPASS_SAFETY_CHECK=true npm publish \"$tarball\"",
+    "tarballName": "jq --raw-output '.name + \"-\" + .version + \".tgz\"' package.json",
     "copyTestFiles": "cp -r ./test/resources ./dist/test/",
     "pretest": "npm run lint && npm run build && npm run copyTestFiles",
     "test": "cd dist && tape ./test/index.js",
@@ -32,15 +35,15 @@
     "node": ">=10.0.0"
   },
   "files": [
-    "dist/abi.js",
-    "dist/index.js",
-    "dist/linker.js",
-    "dist/smtchecker.js",
-    "dist/smtsolver.js",
-    "dist/solc.js",
-    "dist/soljson.js",
-    "dist/translate.js",
-    "dist/wrapper.js"
+    "abi.js",
+    "index.js",
+    "linker.js",
+    "smtchecker.js",
+    "smtsolver.js",
+    "solc.js",
+    "soljson.js",
+    "translate.js",
+    "wrapper.js"
   ],
   "author": "chriseth",
   "license": "MIT",

--- a/smtchecker.ts
+++ b/smtchecker.ts
@@ -36,7 +36,7 @@ function smtCallback (solverFunction, solver?: any) {
   };
 }
 
-export default {
+export = {
   handleSMTQueries,
   smtCallback
 };

--- a/smtsolver.ts
+++ b/smtsolver.ts
@@ -67,7 +67,7 @@ function solve (query, solver) {
   return solverOutput;
 }
 
-export default {
+export = {
   smtSolver: solve,
   availableSolvers: solvers
 };

--- a/solc.ts
+++ b/solc.ts
@@ -4,7 +4,7 @@ import * as commander from 'commander';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import * as solc from './index';
+import solc from './index';
 import smtchecker from './smtchecker';
 import smtsolver from './smtsolver';
 

--- a/test/abi.ts
+++ b/test/abi.ts
@@ -1,4 +1,4 @@
-import * as tape from 'tape';
+import tape from 'tape';
 import abi from '../abi';
 
 tape('ABI translator', function (t) {

--- a/test/cli.ts
+++ b/test/cli.ts
@@ -1,7 +1,7 @@
-import * as tape from 'tape';
-import * as spawn from 'tape-spawn';
+import tape from 'tape';
+import spawn from 'tape-spawn';
 import * as path from 'path';
-import * as pkg from '../package.json';
+const pkg = require('../package.json');
 
 tape('CLI', function (t) {
   t.test('--version', function (st) {

--- a/test/compiler.ts
+++ b/test/compiler.ts
@@ -1,7 +1,7 @@
-import * as assert from 'assert';
-import * as tape from 'tape';
+import assert from 'assert';
+import tape from 'tape';
 import * as semver from 'semver';
-import * as solc from '../';
+import solc from '../';
 import linker from '../linker';
 import { execSync } from 'child_process';
 import wrapper from '../wrapper';

--- a/test/linker.ts
+++ b/test/linker.ts
@@ -1,4 +1,4 @@
-import * as tape from 'tape';
+import tape from 'tape';
 import linker from '../linker';
 
 tape('Link references', function (t) {

--- a/test/smtcallback.ts
+++ b/test/smtcallback.ts
@@ -1,9 +1,9 @@
-import * as assert from 'assert';
-import * as tape from 'tape';
+import assert from 'assert';
+import tape from 'tape';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as semver from 'semver';
-import * as solc from '../';
+import solc from '../';
 import smtchecker from '../smtchecker';
 import smtsolver from '../smtsolver';
 

--- a/test/smtchecker.ts
+++ b/test/smtchecker.ts
@@ -1,6 +1,6 @@
-import * as tape from 'tape';
+import tape from 'tape';
 import * as semver from 'semver';
-import * as solc from '../';
+import solc from '../';
 import smtchecker from '../smtchecker';
 import smtsolver from '../smtsolver';
 

--- a/test/translate.ts
+++ b/test/translate.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import * as tape from 'tape';
+import tape from 'tape';
 import translate from '../translate';
 
 const versionToSemver = translate.versionToSemver;

--- a/translate.ts
+++ b/translate.ts
@@ -193,7 +193,7 @@ function prettyPrintLegacyAssemblyJSON (assembly, source) {
   return formatAssemblyText(assembly, '', source);
 }
 
-export default {
+export = {
   versionToSemver,
   translateJsonCompilerOutput,
   prettyPrintLegacyAssemblyJSON

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,10 @@
     "target": "esnext",
     "module": "commonjs",
     "resolveJsonModule": true,
+    // This is needed for backwards-compatibility, to keep imports of the form `wrapper = require('solc/wrapper)`
+    // working like they did before the TypeScript migration.
+    // TODO: Drop it in the next breaking release.
+    "esModuleInterop": true,
     "outDir": "./dist",
     "forceConsistentCasingInFileNames": true,
     // Allow JS must be included to ensure that the built binary is included

--- a/verifyVersion.ts
+++ b/verifyVersion.ts
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 
 import * as semver from 'semver';
+import solc from './';
 
-import { version as packageVersion } from './package.json';
-import * as solc from './';
+const { version: packageVersion } = require('./package.json');
 
 const solcVersion = (solc as any).version();
 

--- a/wrapper.ts
+++ b/wrapper.ts
@@ -1,7 +1,7 @@
 import translate from './translate';
 import { https } from 'follow-redirects';
-import * as MemoryStream from 'memorystream';
-import * as assert from 'assert';
+import MemoryStream from 'memorystream';
+import assert from 'assert';
 import * as semver from 'semver';
 
 const Module = module.constructor as any;
@@ -357,4 +357,4 @@ function setupMethods (soljson) {
   };
 }
 
-export default setupMethods;
+export = setupMethods;


### PR DESCRIPTION
~Depends on #595. Should not be merged before that PR.~ Merged.

# Why?

When releasing the package, and users begin to use the application, the following is a example import which can take place.

```js
const wrapper = require('solc/wrapper');
```

With the introduction of the typescript support, the content is built into the dist folder. Resulting in the build folder to look like the following.

```
package.json
dist/wrapper.js
dist/solc.js
```

The following change ensures that we publish the dist folder directly which will result in a flatten published folder like the following 

```
package.json
wrapper.js
solc.js
```

which will allow the code example to function correctly without changing the import path to `solc/dist/wrapper`. This change will go in hand with the following PR #595 to allow the commonjs imports to function as expected without breaking backwards compatibility.

# Release Change

Executing `npm publish` or `npm pack` will now be rejected by the application. This is because we want to pack, build and release the built dist folder. By breaking out the process into `build:tarball` and `publish:tarball` the user has more fine control over the process. With additional support for testing.

Running `npm pack` or `npm publish` will show the following error: Run `npm run build:tarball` or `npm run publish:tarball` to pack or publish the package`

## Commands

`npm run build:tarball` will update the binary, build the project and pack the dist folder. The tarball would be created as solc-{version}
`npm run publish:tarball` will locate the tarball file and publish it. If it is not located then the process is closed and the user is notified.