### PR TITLE
Flatten typescript build output into root directly for simplification

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,5 +18,5 @@ module.exports = {
   rules: {
     semi: ['error', 'always']
   },
-  ignorePatterns: ['dist', 'soljson.js']
+  ignorePatterns: ['*.js']
 };

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,8 @@ out
 dist/**
 
 .nyc_output
+
+# ignore all generated js files which can be put into this project.
+# Since we want to keep a flat structure we must first ensure they
+# are ignored in the commit.
+*.js

--- a/build/clean.js
+++ b/build/clean.js
@@ -1,8 +1,0 @@
-const fs = require('fs');
-const path = require('path');
-
-const distFolder = path.join(__dirname, 'dist');
-
-if (fs.existsSync(distFolder)) {
-  fs.rmdirSync(distFolder);
-}

--- a/build/postbuild.js
+++ b/build/postbuild.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
 const path = require('path');
 
-fs.chmodSync(path.join(__dirname, '../dist', 'solc.js'), '755');
+fs.chmodSync(path.join(__dirname, '../', 'solc.js'), '755');
+

--- a/package.json
+++ b/package.json
@@ -8,17 +8,16 @@
   },
   "scripts": {
     "build": "tsc",
-    "postbuild": "node build/postbuild.js",
-    "lint": "eslint --ext .js,.ts .",
-    "lint:fix": "eslint --fix --ext .js,.ts .",
-    "updateBinary": "node build/clean.js && ts-node ./downloadCurrentVersion.ts && ts-node ./verifyVersion.ts",
+    "lint": "eslint --ext .ts .",
+    "lint:fix": "eslint --fix --ext .ts .",
+    "postbuild": "node ./build/postbuild.js",
+    "updateBinary": "ts-node ./downloadCurrentVersion.ts && ts-node ./verifyVersion.ts",
     "prepack": "node build/pack-publish-block.js",
-    "build:tarball": "npm run updateBinary && npm run build && BYPASS_SAFETY_CHECK=true npm pack ./dist",
+    "build:tarball": "npm run updateBinary && npm run build && BYPASS_SAFETY_CHECK=true npm pack ./",
     "publish:tarball": "tarball=$(npm run --silent tarballName) && ls \"$tarball\" && BYPASS_SAFETY_CHECK=true npm publish \"$tarball\"",
     "tarballName": "jq --raw-output '.name + \"-\" + .version + \".tgz\"' package.json",
-    "copyTestFiles": "cp -r ./test/resources ./dist/test/",
-    "pretest": "npm run lint && npm run build && npm run copyTestFiles",
-    "test": "cd dist && tape ./test/index.js",
+    "pretest": "npm run lint && npm run build",
+    "test": "tape ./test/index.js",
     "coverage": "nyc npm run test",
     "coveralls": "npm run coverage && coveralls <coverage/lcov.info"
   },
@@ -81,8 +80,7 @@
   },
   "nyc": {
     "exclude": [
-      "soljson.js",
-      "dist"
+      "soljson.js"
     ]
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     // working like they did before the TypeScript migration.
     // TODO: Drop it in the next breaking release.
     "esModuleInterop": true,
-    "outDir": "./dist",
+    "outDir": "./",
     "forceConsistentCasingInFileNames": true,
     // Allow JS must be included to ensure that the built binary is included
     // in the output. This could be copied directly in the future if required.
@@ -20,13 +20,11 @@
     "noImplicitAny": false
   },
   "include": [
-    "**/*.js",
     "**/*.ts",
     "**/*.json"
   ],
   "exclude": [
-    "coverage",
-    "dist"
+    "coverage"
   ],
   "ts-node": {
     "transpileOnly": true


### PR DESCRIPTION
# Why?

This flattens the entire typescript build output into the root directly, which in turn removes the need for the `dist` folder. This might make it more complicated when developing if you see the side by side `.js` and `.ts` files but allows for a better experience for the user.

* `npm updateBinary` will update the local `soljson.js` for the current built content as well. Meaning that the user will not have to `run npm` build again if they have updated the binary.
 
* This additionally removes some commands which are no longer required since everything is pushed into the root folder.

## Breaking
* Anything that references the `dist` folder in the main repository would now have to reference the root directly again. This could be a breaking change if a release has already been made. 
* Any tests that reference the dist folder will have to be changed to the root directly.
* Users will see no change if they install from npm since the package and release commands will continue to release the same content.