### PR TITLE
Refactor and provide type support to linker.ts 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ out
 dist/**
 
 .nyc_output
+.idea
+.DS_Store

--- a/common/helpers.ts
+++ b/common/helpers.ts
@@ -1,0 +1,24 @@
+/**
+ * returns true if and only if the value is null or undefined.
+ * Uses == over === which compares both null and undefined.
+ * @param value
+ */
+function isNil (value: any): boolean {
+  return value == null;
+}
+
+/**
+ * returns true if and only if the value is a object and not an array
+ *
+ * typeof [] will result in a 'object' so this additonally uses Array.isArray
+ * to confirm its just a object.
+ *
+ * @param value
+ */
+function isObject (value: any): boolean {
+  return typeof value === 'object' && !Array.isArray(value);
+}
+
+export {
+  isNil, isObject
+};

--- a/common/types.ts
+++ b/common/types.ts
@@ -1,0 +1,15 @@
+/**
+ * A mapping between the library name and the target address location.
+ *
+ * Containing support for two level configuration.
+ */
+export interface LibraryPlaceholdersMapping {
+  [libraryName: string]: string | { [location: string]: string };
+}
+
+/**
+ * A mapping between library name and the largest offset witin the byte code.
+ */
+export interface LinkReferences {
+  [libraryName: string]: Array<{ start: number, length: number }>;
+}

--- a/linker.ts
+++ b/linker.ts
@@ -1,65 +1,125 @@
 import assert from 'assert';
 import { keccak256 } from 'js-sha3';
+import { isNil, isObject } from './common/helpers';
+import { LibraryPlaceholdersMapping, LinkReferences } from './common/types';
 
-function libraryHashPlaceholder (input) {
-  return '$' + keccak256(input).slice(0, 34) + '$';
+/**
+ * Newer versions of the compiler use hashed names instead of the string values.
+ *
+ * This helper makes the conversion between name and hash at the target length
+ * for replacement.
+ *
+ * @param libraryName
+ */
+function libraryHashPlaceholder (libraryName: string) {
+  return `$${keccak256(libraryName).slice(0, 34)}$`;
 }
 
-const linkBytecode = function (bytecode, libraries) {
+/**
+ * Used to support legacy library names and the current hash library names,
+ * replaces the names with the provided hex address.
+ *
+ * @param bytecode
+ * @param hexAddress
+ * @param labelName
+ */
+function replacePlaceholderLabelWithHexAddress (bytecode: string, hexAddress: string, labelName: string): string {
+  // truncate to 36 characters, why, I assume this is because legacy names
+  // only had a length of 36 characters?
+  const truncatedName = labelName.slice(0, 36);
+
+  const prefix = '__';
+  const postFix = `${Array(37 - truncatedName.length).join('_')}__`;
+  const libLabel = `${prefix}${truncatedName}${postFix}`;
+
+  while (bytecode.indexOf(libLabel) >= 0) {
+    bytecode = bytecode.replace(libLabel, hexAddress);
+  }
+
+  return bytecode;
+}
+
+/**
+ * When using libraries, the resulting bytecode will contain placeholders for
+ * the real addresses of the referenced libraries. These have to be updated,
+ * via a process called linking, before deploying the contract.
+ *
+ * This method provides a simple helper for linking.
+ *
+ * @param {string} bytecode
+ * @param {string} libraries
+ * @returns {string} bytecode
+ */
+function linkBytecode (bytecode: string, libraries: LibraryPlaceholdersMapping): string {
   assert(typeof bytecode === 'string');
   assert(typeof libraries === 'object');
+
   // NOTE: for backwards compatibility support old compiler which didn't use file names
-  const librariesComplete = {};
-  for (const libraryName in libraries) {
-    if (typeof libraries[libraryName] === 'object') {
-      // API compatible with the standard JSON i/o
-      for (const lib in libraries[libraryName]) {
-        librariesComplete[lib] = libraries[libraryName][lib];
-        librariesComplete[libraryName + ':' + lib] = libraries[libraryName][lib];
+  const librariesComplete: { [x: string]: string } = {};
+
+  for (const [libraryName, library] of Object.entries(libraries)) {
+    if (isNil(library)) continue;
+
+    // API compatible with the standard JSON i/o
+    if (isObject(library)) {
+      for (const [key, value] of Object.entries(library)) {
+        librariesComplete[key] = value;
+        librariesComplete[`${libraryName}:${key}`] = value;
       }
-    } else {
-      // backwards compatible API for early solc-js versions
-      const parsed = libraryName.match(/^([^:]+):(.+)$/);
-      if (parsed) {
-        librariesComplete[parsed[2]] = libraries[libraryName];
-      }
-      librariesComplete[libraryName] = libraries[libraryName];
+
+      continue;
     }
+
+    // backwards compatible API for early solc-js versions
+    const parsed = libraryName.match(/^([^:]+):(.+)$/);
+
+    if (!isNil(parsed)) librariesComplete[parsed[2]] = library as string;
+    librariesComplete[libraryName] = library as string;
   }
 
   for (const libraryName in librariesComplete) {
     let hexAddress = librariesComplete[libraryName];
-    if (hexAddress.slice(0, 2) !== '0x' || hexAddress.length > 42) {
-      throw new Error('Invalid address specified for ' + libraryName);
+
+    if (!hexAddress.startsWith('0x') || hexAddress.length > 42) {
+      throw new Error(`Invalid address specified for ${libraryName}`);
     }
+
     // remove 0x prefix
     hexAddress = hexAddress.slice(2);
     hexAddress = Array(40 - hexAddress.length + 1).join('0') + hexAddress;
 
-    // Support old (library name) and new (hash of library name)
-    // placeholders.
-    const replace = function (name) {
-      // truncate to 37 characters
-      const truncatedName = name.slice(0, 36);
-      const libLabel = '__' + truncatedName + Array(37 - truncatedName.length).join('_') + '__';
-      while (bytecode.indexOf(libLabel) >= 0) {
-        bytecode = bytecode.replace(libLabel, hexAddress);
-      }
-    };
-
-    replace(libraryName);
-    replace(libraryHashPlaceholder(libraryName));
+    // replace all library names with a hex address of all zeros of length
+    // (40 - len(hexAddress) + 1) + the org hex address without the prefix.
+    //
+    // and then again for the hash version of hte library name.
+    bytecode = replacePlaceholderLabelWithHexAddress(bytecode, hexAddress, libraryName);
+    bytecode = replacePlaceholderLabelWithHexAddress(bytecode, hexAddress, libraryHashPlaceholder(libraryName));
   }
 
   return bytecode;
-};
+}
 
-const findLinkReferences = function (bytecode) {
+/**
+ * As of Solidity 0.4.11 the compiler supports standard JSON input and output
+ * which outputs a _link references_ map. This gives a map of library names to
+ * offsets in the bytecode to replace the addresses at. It also doesn't have
+ * the limitation on library file and contract name lengths.
+ *
+ * There is a method available here which can find such link references in
+ * bytecode produced by an older compiler.
+ *
+ * @param {string} bytecode
+ * @returns {string} LinkedReferences
+ */
+function findLinkReferences (bytecode: string): LinkReferences {
   assert(typeof bytecode === 'string');
+
   // find 40 bytes in the pattern of __...<36 digits>...__
   // e.g. __Lib.sol:L_____________________________
-  const linkReferences = {};
+  const linkReferences: LinkReferences = {};
+
   let offset = 0;
+
   while (true) {
     const found = bytecode.match(/__(.{36})__/);
     if (!found) {
@@ -67,6 +127,7 @@ const findLinkReferences = function (bytecode) {
     }
 
     const start = found.index;
+
     // trim trailing underscores
     // NOTE: this has no way of knowing if the trailing underscore was part of the name
     const libraryName = found[1].replace(/_+$/gm, '');
@@ -75,18 +136,18 @@ const findLinkReferences = function (bytecode) {
       linkReferences[libraryName] = [];
     }
 
+    // offsets are in bytes in binary representation (and not hex)
     linkReferences[libraryName].push({
-      // offsets are in bytes in binary representation (and not hex)
       start: (offset + start) / 2,
       length: 20
     });
 
     offset += start + 20;
-
     bytecode = bytecode.slice(start + 20);
   }
+
   return linkReferences;
-};
+}
 
 export = {
   linkBytecode,


### PR DESCRIPTION
# Why

This change provides some basic type support for the internal and exported methods within `linker.ts`, includes support documentation where missing for the consumer. The target result of this `PR` is to increase readability, maintainability and start the introduction of types.

This is the continuous development happening on top of #566 to improve user consumption, and development experience. 

Depends on #594 