### PR TITLE
Provide type support to linker.ts 

### DIFF
--- a/common/types.ts
+++ b/common/types.ts
@@ -1,0 +1,26 @@
+/**
+ * A mapping between libraries and the addresses to which they were deployed.
+ *
+ * Containing support for two level configuration, These two level
+ * configurations can be seen below.
+ *
+ * {
+ *     "lib.sol:L1": "0x...",
+ *     "lib.sol:L2": "0x...",
+ *     "lib.sol": {"L3": "0x..."}
+ * }
+ */
+export interface LibraryAddresses {
+  [qualifiedNameOrSourceUnit: string]: string | { [unqualifiedLibraryName: string]: string };
+}
+
+/**
+ * A mapping between libraries and lists of placeholder instances present in their hex-encoded bytecode.
+ * For each placeholder its length and the position of the first character is stored.
+ *
+ * Each start and length entry will always directly refer to the position in
+ * binary and not hex-encoded bytecode.
+ */
+export interface LinkReferences {
+  [libraryLabel: string]: Array<{ start: number, length: number }>;
+}

--- a/linker.ts
+++ b/linker.ts
@@ -1,6 +1,7 @@
 import assert from 'assert';
 import { keccak256 } from 'js-sha3';
 import { isNil, isObject } from './common/helpers';
+import { LibraryAddresses, LinkReferences } from './common/types';
 
 /**
  * Generates a new-style library placeholder from a fully-qualified library name.
@@ -57,12 +58,12 @@ function replacePlaceholder (bytecode, label, address) {
  * @returns bytecode Hex-encoded bytecode string with placeholders replaced with addresses.
  *    Note that some placeholders may remain in the bytecode if `libraries` does not provide addresses for all of them.
  */
-function linkBytecode (bytecode, libraries) {
+function linkBytecode (bytecode: string, libraries: LibraryAddresses): string {
   assert(typeof bytecode === 'string');
   assert(typeof libraries === 'object');
 
   // NOTE: for backwards compatibility support old compiler which didn't use file names
-  const librariesComplete = {};
+  const librariesComplete: { [fullyQualifiedLibraryName: string]: string } = {};
 
   for (const [fullyQualifiedLibraryName, libraryObjectOrAddress] of Object.entries(libraries)) {
     if (isNil(libraryObjectOrAddress)) {
@@ -136,12 +137,12 @@ function linkBytecode (bytecode, libraries) {
  * offsets and lengths refer to the *binary* (not hex-encoded) bytecode, just
  * like in `evm.bytecode.linkReferences`.
  */
-function findLinkReferences (bytecode) {
+function findLinkReferences (bytecode: string): LinkReferences {
   assert(typeof bytecode === 'string');
 
   // find 40 bytes in the pattern of __...<36 digits>...__
   // e.g. __Lib.sol:L_____________________________
-  const linkReferences = {};
+  const linkReferences: LinkReferences = {};
 
   let offset = 0;
 


### PR DESCRIPTION
# Why

This change provides some basic type support for the internal and exported methods within `linker.ts`, includes support documentation where missing for the consumer. The target result of this `PR` is to increase readability, maintainability and start the introduction of types.

This is the continuous development happening on top of #566 to improve user consumption, and development experience. 

Depends on #603 and #594 

## Note

This is currently rebased on #603 so just validate the latest commit.