### PR TITLE
LSP Integration: simple refactor to resolve linting and legacy variables

### DIFF
--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -1,9 +1,8 @@
 export interface ReadCallbackReply {
   error?: string;
-  contents?: string
+  contents?: string;
 }
 
 export interface Callbacks {
-    import(path: string): ReadCallbackReply;
+  import (path: string): ReadCallbackReply;
 }
-


### PR DESCRIPTION
## Linting & Refactoring

This will resolve any linting concerns that would block this from passing the linting requirements. Additionally, this upgrades vars to let and const where applicable for maintainability. 

## Binary support checks

When performing binary support checks, always return a function that is callable from the consumer. This can just error for example in the below implementation. Reducing the need for complicated backward compatibility requirements when future changes occur. 

```js
if (!('_solidity_lsp_start' in soljson)) {
    return () => {
      throw new Error('lsp is not supported on this version.');
    };
}
```

## The Future

`wrapper.js` has a plan refactor to simplify maintainability and remove some of the complicated nested function calls. This change will be included in that so I did not make any additional changes outside of the current `wrapper.js` flow.