### PR TITLE
Add `yarn build` to `hardhat-core-default-solc` job to work around broken parallel tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,6 +179,9 @@ jobs:
           name: Run hardhat-core test suite with its default solc
           command: |
             cd hardhat/packages/hardhat-core
+            # TODO: yarn build should not be needed to run these tests. Remove it.
+            # See https://github.com/NomicFoundation/hardhat/issues/2486 for details.
+            yarn build
             yarn test
 
   hardhat-core-latest-solc:


### PR DESCRIPTION
Workaround for https://github.com/NomicFoundation/hardhat/issues/2486.