### PR TITLE
Refactor wrapper.ts to improve maintainability

### DIFF
--- a/bindings/compile.ts
+++ b/bindings/compile.ts
@@ -1,0 +1,232 @@
+import assert from 'assert';
+
+import { isNil } from '../common/helpers';
+import { bindSolcMethod } from './helpers';
+
+export function setupCompile (solJson, core) {
+  return {
+    compileJson: bindCompileJson(solJson),
+    compileJsonCallback: bindCompileJsonCallback(solJson, core),
+    compileJsonMulti: bindCompileJsonMulti(solJson),
+    compileStandard: bindCompileStandard(solJson, core)
+  };
+}
+
+/**********************
+ * COMPILE
+ **********************/
+
+/**
+ * Returns a binding to the solidity compileJSON method.
+ * input (text), optimize (bool) -> output (jsontext)
+ *
+ * @param solJson The Emscripten compiled Solidity object.
+ */
+function bindCompileJson (solJson) {
+  return bindSolcMethod(
+    solJson,
+    'compileJSON',
+    'string',
+    ['string', 'number'],
+    null
+  );
+}
+
+/**
+ * Returns a binding to the solidity compileJSONMulti method.
+ * input (jsontext), optimize (bool) -> output (jsontext)
+ *
+ * @param solJson The Emscripten compiled Solidity object.
+ */
+function bindCompileJsonMulti (solJson) {
+  return bindSolcMethod(
+    solJson,
+    'compileJSONMulti',
+    'string',
+    ['string', 'number'],
+    null
+  );
+}
+
+/**
+ * Returns a binding to the solidity compileJSONCallback method.
+ * input (jsontext), optimize (bool), callback (ptr) -> output (jsontext)
+ *
+ * @param solJson The Emscripten compiled Solidity object.
+ * @param coreBindings The core bound Solidity methods.
+ */
+function bindCompileJsonCallback (solJson, coreBindings) {
+  const compileInternal = bindSolcMethod(
+    solJson,
+    'compileJSONCallback',
+    'string',
+    ['string', 'number', 'number'],
+    null
+  );
+
+  if (isNil(compileInternal)) return null;
+
+  return function (input, optimize, readCallback) {
+    return runWithCallbacks(solJson, coreBindings, readCallback, compileInternal, [input, optimize]);
+  };
+}
+
+/**
+ * Returns a binding to the solidity solidity_compile method with a fallback to
+ * compileStandard.
+ * input (jsontext), callback (optional >= v6 only - ptr) -> output (jsontext)
+ *
+ * @param solJson The Emscripten compiled Solidity object.
+ * @param coreBindings The core bound Solidity methods.
+ */
+function bindCompileStandard (solJson, coreBindings) {
+  let boundFunctionStandard: any = null;
+  let boundFunctionSolidity: any = null;
+
+  // input (jsontext), callback (ptr) -> output (jsontext)
+  const compileInternal = bindSolcMethod(
+    solJson,
+    'compileStandard',
+    'string',
+    ['string', 'number'],
+    null
+  );
+
+  if (coreBindings.isVersion6OrNewer) {
+    // input (jsontext), callback (ptr), callback_context (ptr) -> output (jsontext)
+    boundFunctionSolidity = bindSolcMethod(
+      solJson,
+      'solidity_compile',
+      'string',
+      ['string', 'number', 'number'],
+      null
+    );
+  } else {
+    // input (jsontext), callback (ptr) -> output (jsontext)
+    boundFunctionSolidity = bindSolcMethod(
+      solJson,
+      'solidity_compile',
+      'string',
+      ['string', 'number'],
+      null
+    );
+  }
+
+  if (!isNil(compileInternal)) {
+    boundFunctionStandard = function (input, readCallback) {
+      return runWithCallbacks(solJson, coreBindings, readCallback, compileInternal, [input]);
+    };
+  }
+
+  if (!isNil(boundFunctionSolidity)) {
+    boundFunctionStandard = function (input, callbacks) {
+      return runWithCallbacks(solJson, coreBindings, callbacks, boundFunctionSolidity, [input]);
+    };
+  }
+
+  return boundFunctionStandard;
+}
+
+/**********************
+ * CALL BACKS
+ **********************/
+
+function wrapCallback (coreBindings, callback) {
+  assert(typeof callback === 'function', 'Invalid callback specified.');
+
+  return function (data, contents, error) {
+    const result = callback(coreBindings.copyFromCString(data));
+    if (typeof result.contents === 'string') {
+      coreBindings.copyToCString(result.contents, contents);
+    }
+    if (typeof result.error === 'string') {
+      coreBindings.copyToCString(result.error, error);
+    }
+  };
+}
+
+function wrapCallbackWithKind (coreBindings, callback) {
+  assert(typeof callback === 'function', 'Invalid callback specified.');
+
+  return function (context, kind, data, contents, error) {
+    // Must be a null pointer.
+    assert(context === 0, 'Callback context must be null.');
+    const result = callback(coreBindings.copyFromCString(kind), coreBindings.copyFromCString(data));
+    if (typeof result.contents === 'string') {
+      coreBindings.copyToCString(result.contents, contents);
+    }
+    if (typeof result.error === 'string') {
+      coreBindings.copyToCString(result.error, error);
+    }
+  };
+}
+
+// calls compile() with args || cb
+function runWithCallbacks (solJson, coreBindings, callbacks, compile, args) {
+  if (callbacks) {
+    assert(typeof callbacks === 'object', 'Invalid callback object specified.');
+  } else {
+    callbacks = {};
+  }
+
+  let readCallback = callbacks.import;
+  if (readCallback === undefined) {
+    readCallback = function (data) {
+      return {
+        error: 'File import callback not supported'
+      };
+    };
+  }
+
+  let singleCallback;
+  if (coreBindings.isVersion6OrNewer) {
+    // After 0.6.x multiple kind of callbacks are supported.
+    let smtSolverCallback = callbacks.smtSolver;
+    if (smtSolverCallback === undefined) {
+      smtSolverCallback = function (data) {
+        return {
+          error: 'SMT solver callback not supported'
+        };
+      };
+    }
+
+    singleCallback = function (kind, data) {
+      if (kind === 'source') {
+        return readCallback(data);
+      } else if (kind === 'smt-query') {
+        return smtSolverCallback(data);
+      } else {
+        assert(false, 'Invalid callback kind specified.');
+      }
+    };
+
+    singleCallback = wrapCallbackWithKind(coreBindings, singleCallback);
+  } else {
+    // Old Solidity version only supported imports.
+    singleCallback = wrapCallback(coreBindings, readCallback);
+  }
+
+  const cb = coreBindings.addFunction(singleCallback, 'viiiii');
+  let output;
+  try {
+    args.push(cb);
+    if (coreBindings.isVersion6OrNewer) {
+      // Callback context.
+      args.push(null);
+    }
+
+    output = compile(...args);
+  } finally {
+    coreBindings.removeFunction(cb);
+  }
+
+  if (coreBindings.reset) {
+    // Explicitly free memory.
+    //
+    // NOTE: cwrap() of "compile" will copy the returned pointer into a
+    //       Javascript string and it is not possible to call free() on it.
+    //       reset() however will clear up all allocations.
+    coreBindings.reset();
+  }
+  return output;
+}

--- a/bindings/core.ts
+++ b/bindings/core.ts
@@ -1,0 +1,161 @@
+import { bindSolcMethod, bindSolcMethodWithFallbackFunc } from './helpers';
+import translate from '../translate';
+import * as semver from 'semver';
+import { isNil } from '../common/helpers';
+
+export function setupCore (solJson) {
+  const core = {
+    alloc: bindAlloc(solJson),
+    license: bindLicense(solJson),
+    version: bindVersion(solJson),
+    reset: bindReset(solJson)
+  };
+
+  const helpers = {
+    addFunction: unboundAddFunction.bind(this, solJson),
+    removeFunction: unboundRemoveFunction.bind(this, solJson),
+
+    copyFromCString: unboundCopyFromCString.bind(this, solJson),
+    copyToCString: unboundCopyToCString.bind(this, solJson, core.alloc),
+
+    // @ts-ignore
+    versionToSemver: versionToSemver(core.version())
+  };
+
+  return {
+    ...core,
+    ...helpers,
+
+    isVersion6OrNewer: semver.gt(helpers.versionToSemver(), '0.5.99')
+  };
+}
+
+/**********************
+ * Core Functions
+ **********************/
+
+/**
+ * Returns a binding to the solidity_alloc function.
+ *
+ * @param solJson The Emscripten compiled Solidity object.
+ */
+function bindAlloc (solJson) {
+  const allocBinding = bindSolcMethod(
+    solJson,
+    'solidity_alloc',
+    'number',
+    ['number'],
+    null
+  );
+
+  // the fallback malloc is not a cwrap function and should just be returned
+  // directly in-case the alloc binding could not happen.
+  if (isNil(allocBinding)) {
+    return solJson._malloc;
+  }
+
+  return allocBinding;
+}
+
+/**
+ * Returns a binding to the solidity_version method.
+ *
+ * @param solJson The Emscripten compiled Solidity object.
+ */
+function bindVersion (solJson) {
+  return bindSolcMethodWithFallbackFunc(
+    solJson,
+    'solidity_version',
+    'string',
+    [],
+    'version'
+  );
+}
+
+function versionToSemver (version) {
+  return translate.versionToSemver.bind(this, version);
+}
+
+/**
+ * Returns a binding to the solidity_license method.
+ *
+ * If the current solJson version < 0.4.14 then this will bind an empty function.
+ *
+ * @param solJson The Emscripten compiled Solidity object.
+ */
+function bindLicense (solJson) {
+  return bindSolcMethodWithFallbackFunc(
+    solJson,
+    'solidity_license',
+    'string',
+    [],
+    'license',
+    () => {
+    }
+  );
+}
+
+/**
+ * Returns a binding to the solidity_reset method.
+ *
+ * @param solJson The Emscripten compiled Solidity object.
+ */
+function bindReset (solJson) {
+  return bindSolcMethod(
+    solJson,
+    'solidity_reset',
+    null,
+    [],
+    null
+  );
+}
+
+/**********************
+ * Helpers Functions
+ **********************/
+
+/**
+ * Copy to a C string.
+ *
+ * Allocates memory using solc's allocator.
+ *
+ * Before 0.6.0:
+ *   Assuming copyToCString is only used in the context of wrapCallback, solc will free these pointers.
+ *   See https://github.com/ethereum/solidity/blob/v0.5.13/libsolc/libsolc.h#L37-L40
+ *
+ * After 0.6.0:
+ *   The duty is on solc-js to free these pointers. We accomplish that by calling `reset` at the end.
+ *
+ * @param solJson The Emscripten compiled Solidity object.
+ * @param alloc The memory allocation function.
+ * @param str The source string being copied to a C string.
+ * @param ptr The pointer location where the C string will be set.
+ */
+function unboundCopyToCString (solJson, alloc, str, ptr) {
+  const length = solJson.lengthBytesUTF8(str);
+
+  const buffer = alloc(length + 1);
+
+  solJson.stringToUTF8(str, buffer, length + 1);
+  solJson.setValue(ptr, buffer, '*');
+}
+
+/**
+ * Wrapper over Emscripten's C String copying function (which can be different
+ * on different versions).
+ *
+ * @param solJson The Emscripten compiled Solidity object.
+ * @param ptr The pointer location where the C string will be referenced.
+ */
+function unboundCopyFromCString (solJson, ptr) {
+  const copyFromCString = solJson.UTF8ToString || solJson.Pointer_stringify;
+  return copyFromCString(ptr);
+}
+
+function unboundAddFunction (solJson, func, signature?) {
+  return (solJson.addFunction || solJson.Runtime.addFunction)(func, signature);
+}
+
+function unboundRemoveFunction (solJson, ptr) {
+  return (solJson.removeFunction || solJson.Runtime.removeFunction)(ptr);
+}

--- a/bindings/helpers.ts
+++ b/bindings/helpers.ts
@@ -1,0 +1,36 @@
+import { isNil } from '../common/helpers';
+
+export function bindSolcMethod (solJson, method, returnType, args, defaultValue) {
+  if (isNil(solJson[`_${method}`]) && defaultValue !== undefined) {
+    return defaultValue;
+  }
+
+  return solJson.cwrap(method, returnType, args);
+}
+
+export function bindSolcMethodWithFallbackFunc (solJson, method, returnType, args, fallbackMethod, finalFallback = undefined) {
+  const methodFunc = bindSolcMethod(solJson, method, returnType, args, null);
+
+  if (!isNil(methodFunc)) {
+    return methodFunc;
+  }
+
+  return bindSolcMethod(solJson, fallbackMethod, returnType, args, finalFallback);
+}
+
+export function getSupportedMethods (solJson) {
+  return {
+    licenseSupported: anyMethodExists(solJson, 'solidity_license'),
+    versionSupported: anyMethodExists(solJson, 'solidity_version'),
+    allocSupported: anyMethodExists(solJson, 'solidity_alloc'),
+    resetSupported: anyMethodExists(solJson, 'solidity_reset'),
+    compileJsonSupported: anyMethodExists(solJson, 'compileJSON'),
+    compileJsonMultiSupported: anyMethodExists(solJson, 'compileJSONMulti'),
+    compileJsonCallbackSuppported: anyMethodExists(solJson, 'compileJSONCallback'),
+    compileJsonStandardSupported: anyMethodExists(solJson, 'compileStandard', 'solidity_compile')
+  };
+}
+
+function anyMethodExists (solJson, ...names) {
+  return names.some(name => !isNil(solJson[`_${name}`]));
+}

--- a/bindings/index.ts
+++ b/bindings/index.ts
@@ -1,0 +1,15 @@
+import { setupCore } from './core';
+import { getSupportedMethods } from './helpers';
+import { setupCompile } from './compile';
+
+export default function setupBindings (solJson) {
+  const coreBindings = setupCore(solJson);
+  const compileBindings = setupCompile(solJson, coreBindings);
+  const methodFlags = getSupportedMethods(solJson);
+
+  return {
+    methodFlags,
+    coreBindings,
+    compileBindings
+  };
+}

--- a/formatters.ts
+++ b/formatters.ts
@@ -1,0 +1,13 @@
+export function formatFatalError (message) {
+  return JSON.stringify({
+    errors: [
+      {
+        type: 'JSONError',
+        component: 'solcjs',
+        severity: 'error',
+        message: message,
+        formattedMessage: 'Error: ' + message
+      }
+    ]
+  });
+}

--- a/package.json
+++ b/package.json
@@ -35,16 +35,9 @@
     "node": ">=10.0.0"
   },
   "files": [
-    "abi.js",
-    "index.js",
-    "linker.js",
-    "smtchecker.js",
-    "smtsolver.js",
-    "solc.js",
-    "soljson.js",
-    "translate.js",
-    "wrapper.js",
-    "common/helpers.js"
+    "common/*.js",
+    "bindings/*.js",
+    "*.js"
   ],
   "author": "chriseth",
   "license": "MIT",
@@ -63,9 +56,9 @@
   },
   "devDependencies": {
     "@types/node": "^16.11.7",
-    "@types/tmp": "^0.2.3",
     "@types/semver": "^7.3.9",
     "@types/tape": "^4.13.2",
+    "@types/tmp": "^0.2.3",
     "@typescript-eslint/eslint-plugin": "^5.8.0",
     "@typescript-eslint/parser": "^5.8.0",
     "coveralls": "^3.0.0",

--- a/wrapper.ts
+++ b/wrapper.ts
@@ -1,360 +1,169 @@
-import translate from './translate';
-import { https } from 'follow-redirects';
 import MemoryStream from 'memorystream';
-import assert from 'assert';
-import * as semver from 'semver';
+import { https } from 'follow-redirects';
+
+import { formatFatalError } from './formatters';
+import { isNil } from './common/helpers';
+import setupBindings from './bindings';
+import translate from './translate';
 
 const Module = module.constructor as any;
 
-function setupMethods (soljson) {
-  let version;
-  if ('_solidity_version' in soljson) {
-    version = soljson.cwrap('solidity_version', 'string', []);
-  } else {
-    version = soljson.cwrap('version', 'string', []);
-  }
-
-  const versionToSemver = function () {
-    return translate.versionToSemver(version());
-  };
-
-  const isVersion6 = semver.gt(versionToSemver(), '0.5.99');
-
-  let license;
-  if ('_solidity_license' in soljson) {
-    license = soljson.cwrap('solidity_license', 'string', []);
-  } else if ('_license' in soljson) {
-    license = soljson.cwrap('license', 'string', []);
-  } else {
-    // pre 0.4.14
-    license = function () {
-      // return undefined
-    };
-  }
-
-  let alloc;
-  if ('_solidity_alloc' in soljson) {
-    alloc = soljson.cwrap('solidity_alloc', 'number', ['number']);
-  } else {
-    alloc = soljson._malloc;
-    assert(alloc, 'Expected malloc to be present.');
-  }
-
-  let reset;
-  if ('_solidity_reset' in soljson) {
-    reset = soljson.cwrap('solidity_reset', null, []);
-  }
-
-  const copyToCString = function (str, ptr) {
-    const length = soljson.lengthBytesUTF8(str);
-    // This is allocating memory using solc's allocator.
-    //
-    // Before 0.6.0:
-    //   Assuming copyToCString is only used in the context of wrapCallback, solc will free these pointers.
-    //   See https://github.com/ethereum/solidity/blob/v0.5.13/libsolc/libsolc.h#L37-L40
-    //
-    // After 0.6.0:
-    //   The duty is on solc-js to free these pointers. We accomplish that by calling `reset` at the end.
-    const buffer = alloc(length + 1);
-    soljson.stringToUTF8(str, buffer, length + 1);
-    soljson.setValue(ptr, buffer, '*');
-  };
-
-  // This is to support multiple versions of Emscripten.
-  // Take a single `ptr` and returns a `str`.
-  const copyFromCString = soljson.UTF8ToString || soljson.Pointer_stringify;
-
-  const wrapCallback = function (callback) {
-    assert(typeof callback === 'function', 'Invalid callback specified.');
-    return function (data, contents, error) {
-      const result = callback(copyFromCString(data));
-      if (typeof result.contents === 'string') {
-        copyToCString(result.contents, contents);
-      }
-      if (typeof result.error === 'string') {
-        copyToCString(result.error, error);
-      }
-    };
-  };
-
-  const wrapCallbackWithKind = function (callback) {
-    assert(typeof callback === 'function', 'Invalid callback specified.');
-    return function (context, kind, data, contents, error) {
-      // Must be a null pointer.
-      assert(context === 0, 'Callback context must be null.');
-      const result = callback(copyFromCString(kind), copyFromCString(data));
-      if (typeof result.contents === 'string') {
-        copyToCString(result.contents, contents);
-      }
-      if (typeof result.error === 'string') {
-        copyToCString(result.error, error);
-      }
-    };
-  };
-
-  // This calls compile() with args || cb
-  const runWithCallbacks = function (callbacks, compile, args) {
-    if (callbacks) {
-      assert(typeof callbacks === 'object', 'Invalid callback object specified.');
-    } else {
-      callbacks = {};
-    }
-
-    let readCallback = callbacks.import;
-    if (readCallback === undefined) {
-      readCallback = function (data) {
-        return {
-          error: 'File import callback not supported'
-        };
-      };
-    }
-
-    let singleCallback;
-    if (isVersion6) {
-      // After 0.6.x multiple kind of callbacks are supported.
-      let smtSolverCallback = callbacks.smtSolver;
-      if (smtSolverCallback === undefined) {
-        smtSolverCallback = function (data) {
-          return {
-            error: 'SMT solver callback not supported'
-          };
-        };
-      }
-
-      singleCallback = function (kind, data) {
-        if (kind === 'source') {
-          return readCallback(data);
-        } else if (kind === 'smt-query') {
-          return smtSolverCallback(data);
-        } else {
-          assert(false, 'Invalid callback kind specified.');
-        }
-      };
-
-      singleCallback = wrapCallbackWithKind(singleCallback);
-    } else {
-      // Old Solidity version only supported imports.
-      singleCallback = wrapCallback(readCallback);
-    }
-
-    // This is to support multiple versions of Emscripten.
-    const addFunction = soljson.addFunction || soljson.Runtime.addFunction;
-    const removeFunction = soljson.removeFunction || soljson.Runtime.removeFunction;
-
-    const cb = addFunction(singleCallback, 'viiiii');
-    let output;
-    try {
-      args.push(cb);
-      if (isVersion6) {
-        // Callback context.
-        args.push(null);
-      }
-      output = compile.apply(undefined, args);
-    } catch (e) {
-      removeFunction(cb);
-      throw e;
-    }
-    removeFunction(cb);
-    if (reset) {
-      // Explicitly free memory.
-      //
-      // NOTE: cwrap() of "compile" will copy the returned pointer into a
-      //       Javascript string and it is not possible to call free() on it.
-      //       reset() however will clear up all allocations.
-      reset();
-    }
-    return output;
-  };
-
-  let compileJSON = null;
-  if ('_compileJSON' in soljson) {
-    // input (text), optimize (bool) -> output (jsontext)
-    compileJSON = soljson.cwrap('compileJSON', 'string', ['string', 'number']);
-  }
-
-  let compileJSONMulti = null;
-  if ('_compileJSONMulti' in soljson) {
-    // input (jsontext), optimize (bool) -> output (jsontext)
-    compileJSONMulti = soljson.cwrap('compileJSONMulti', 'string', ['string', 'number']);
-  }
-
-  let compileJSONCallback = null;
-  if ('_compileJSONCallback' in soljson) {
-    // input (jsontext), optimize (bool), callback (ptr) -> output (jsontext)
-    const compileInternal = soljson.cwrap('compileJSONCallback', 'string', ['string', 'number', 'number']);
-    compileJSONCallback = function (input, optimize, readCallback) {
-      return runWithCallbacks(readCallback, compileInternal, [input, optimize]);
-    };
-  }
-
-  let compileStandard = null;
-  if ('_compileStandard' in soljson) {
-    // input (jsontext), callback (ptr) -> output (jsontext)
-    const compileStandardInternal = soljson.cwrap('compileStandard', 'string', ['string', 'number']);
-    compileStandard = function (input, readCallback) {
-      return runWithCallbacks(readCallback, compileStandardInternal, [input]);
-    };
-  }
-  if ('_solidity_compile' in soljson) {
-    let solidityCompile;
-    if (isVersion6) {
-      // input (jsontext), callback (ptr), callback_context (ptr) -> output (jsontext)
-      solidityCompile = soljson.cwrap('solidity_compile', 'string', ['string', 'number', 'number']);
-    } else {
-      // input (jsontext), callback (ptr) -> output (jsontext)
-      solidityCompile = soljson.cwrap('solidity_compile', 'string', ['string', 'number']);
-    }
-    compileStandard = function (input, callbacks) {
-      return runWithCallbacks(callbacks, solidityCompile, [input]);
-    };
-  }
-
-  // Expects a Standard JSON I/O but supports old compilers
-  const compileStandardWrapper = function (input, readCallback?: any) {
-    if (compileStandard !== null) {
-      return compileStandard(input, readCallback);
-    }
-
-    function formatFatalError (message) {
-      return JSON.stringify({
-        errors: [
-          {
-            type: 'JSONError',
-            component: 'solcjs',
-            severity: 'error',
-            message: message,
-            formattedMessage: 'Error: ' + message
-          }
-        ]
-      });
-    }
-
-    try {
-      input = JSON.parse(input);
-    } catch (e) {
-      return formatFatalError('Invalid JSON supplied: ' + e.message);
-    }
-
-    if (input.language !== 'Solidity') {
-      return formatFatalError('Only "Solidity" is supported as a language.');
-    }
-
-    // NOTE: this is deliberately `== null`
-    if (input.sources == null || input.sources.length === 0) {
-      return formatFatalError('No input sources specified.');
-    }
-
-    function isOptimizerEnabled (input) {
-      return input.settings && input.settings.optimizer && input.settings.optimizer.enabled;
-    }
-
-    function translateSources (input) {
-      const sources = {};
-      for (const source in input.sources) {
-        if (input.sources[source].content !== null) {
-          sources[source] = input.sources[source].content;
-        } else {
-          // force failure
-          return null;
-        }
-      }
-      return sources;
-    }
-
-    function librariesSupplied (input) {
-      if (input.settings) {
-        return input.settings.libraries;
-      }
-    }
-
-    function translateOutput (output, libraries) {
-      try {
-        output = JSON.parse(output);
-      } catch (e) {
-        return formatFatalError('Compiler returned invalid JSON: ' + e.message);
-      }
-      output = translate.translateJsonCompilerOutput(output, libraries);
-      if (output == null) {
-        return formatFatalError('Failed to process output.');
-      }
-      return JSON.stringify(output);
-    }
-
-    const sources = translateSources(input);
-    if (sources === null || Object.keys(sources).length === 0) {
-      return formatFatalError('Failed to process sources.');
-    }
-
-    // Try linking if libraries were supplied
-    const libraries = librariesSupplied(input);
-
-    // Try to wrap around old versions
-    if (compileJSONCallback !== null) {
-      return translateOutput(compileJSONCallback(JSON.stringify({ sources: sources }), isOptimizerEnabled(input), readCallback), libraries);
-    }
-
-    if (compileJSONMulti !== null) {
-      return translateOutput(compileJSONMulti(JSON.stringify({ sources: sources }), isOptimizerEnabled(input)), libraries);
-    }
-
-    // Try our luck with an ancient compiler
-    if (compileJSON !== null) {
-      if (Object.keys(sources).length !== 1) {
-        return formatFatalError('Multiple sources provided, but compiler only supports single input.');
-      }
-      return translateOutput(compileJSON(sources[Object.keys(sources)[0]], isOptimizerEnabled(input)), libraries);
-    }
-
-    return formatFatalError('Compiler does not support any known interface.');
-  };
+function wrapper (soljson) {
+  const {
+    coreBindings,
+    compileBindings,
+    methodFlags
+  } = setupBindings(soljson);
 
   return {
-    version: version,
-    semver: versionToSemver,
-    license: license,
+    version: coreBindings.version,
+    semver: coreBindings.versionToSemver,
+    license: coreBindings.license,
     lowlevel: {
-      compileSingle: compileJSON,
-      compileMulti: compileJSONMulti,
-      compileCallback: compileJSONCallback,
-      compileStandard: compileStandard
+      compileSingle: compileBindings.compileJson,
+      compileMulti: compileBindings.compileJsonMulti,
+      compileCallback: compileBindings.compileJsonCallback,
+      compileStandard: compileBindings.compileStandard
     },
     features: {
-      legacySingleInput: compileJSON !== null,
-      multipleInputs: compileJSONMulti !== null || compileStandard !== null,
-      importCallback: compileJSONCallback !== null || compileStandard !== null,
-      nativeStandardJSON: compileStandard !== null
+      legacySingleInput: methodFlags.compileJsonStandardSupported,
+      multipleInputs: methodFlags.compileJsonMultiSupported || methodFlags.compileJsonStandardSupported,
+      importCallback: methodFlags.compileJsonCallbackSuppported || methodFlags.compileJsonStandardSupported,
+      nativeStandardJSON: methodFlags.compileJsonStandardSupported
     },
-    compile: compileStandardWrapper,
+    compile: compileStandardWrapper.bind(this, compileBindings),
     // Loads the compiler of the given version from the github repository
     // instead of from the local filesystem.
-    loadRemoteVersion: function (versionString, cb) {
-      const mem = new MemoryStream(null, { readable: false });
-      const url = 'https://binaries.soliditylang.org/bin/soljson-' + versionString + '.js';
-      https.get(url, function (response) {
-        if (response.statusCode !== 200) {
-          cb(new Error('Error retrieving binary: ' + response.statusMessage));
-        } else {
-          response.pipe(mem);
-          response.on('end', function () {
-            // Based on the require-from-string package.
-            const soljson = new Module();
-            soljson._compile(mem.toString(), 'soljson-' + versionString + '.js');
-            if (module.parent && module.parent.children) {
-              // Make sure the module is plugged into the hierarchy correctly to have parent
-              // properly garbage collected.
-              module.parent.children.splice(module.parent.children.indexOf(soljson), 1);
-            }
-
-            cb(null, setupMethods(soljson.exports));
-          });
-        }
-      }).on('error', function (error) {
-        cb(error);
-      });
-    },
+    loadRemoteVersion,
     // Use this if you want to add wrapper functions around the pure module.
-    setupMethods: setupMethods
+    setupMethods: wrapper
   };
 }
 
-export = setupMethods;
+function loadRemoteVersion (versionString, callback) {
+  const memoryStream = new MemoryStream(null, { readable: false });
+  const url = `https://binaries.soliditylang.org/bin/soljson-${versionString}.js`;
+
+  https.get(url, response => {
+    if (response.statusCode !== 200) {
+      callback(new Error(`Error retrieving binary: ${response.statusMessage}`));
+    } else {
+      response.pipe(memoryStream);
+      response.on('end', () => {
+        // Based on the require-from-string package.
+        const soljson = new Module();
+        soljson._compile(memoryStream.toString(), `soljson-${versionString}.js`);
+
+        if (module.parent && module.parent.children) {
+          // Make sure the module is plugged into the hierarchy correctly to have parent
+          // properly garbage collected.
+          module.parent.children.splice(module.parent.children.indexOf(soljson), 1);
+        }
+
+        callback(null, wrapper(soljson.exports));
+      });
+    }
+  }).on('error', function (error) {
+    callback(error);
+  });
+}
+
+// Expects a Standard JSON I/O but supports old compilers
+function compileStandardWrapper (compile, inputRaw, readCallback) {
+  if (!isNil(compile.compileStandard)) {
+    return compile.compileStandard(inputRaw, readCallback);
+  }
+
+  let input: { language: string, sources: any[], settings: any };
+
+  try {
+    input = JSON.parse(inputRaw);
+  } catch (e) {
+    return formatFatalError(`Invalid JSON supplied: ${e.message}`);
+  }
+
+  if (input.language !== 'Solidity') {
+    return formatFatalError('Only "Solidity" is supported as a language.');
+  }
+
+  // NOTE: this is deliberately `== null`
+  if (isNil(input.sources) || input.sources.length === 0) {
+    return formatFatalError('No input sources specified.');
+  }
+
+  const sources = translateSources(input);
+  const optimize = isOptimizerEnabled(input);
+  const libraries = librariesSupplied(input);
+
+  if (isNil(sources) || Object.keys(sources).length === 0) {
+    return formatFatalError('Failed to process sources.');
+  }
+
+  // Try to wrap around old versions
+  if (!isNil(compile.compileJsonCallback)) {
+    const inputJson = JSON.stringify({ sources: sources });
+    const output = compile.compileJsonCallback(inputJson, optimize, readCallback);
+    return translateOutput(output, libraries);
+  }
+
+  if (!isNil(compile.compileJsonMulti)) {
+    const output = compile.compileJsonMulti(JSON.stringify({ sources: sources }), optimize);
+    return translateOutput(output, libraries);
+  }
+
+  // Try our luck with an ancient compiler
+  if (!isNil(compile.compileJson)) {
+    if (Object.keys(sources).length > 1) {
+      return formatFatalError('Multiple sources provided, but compiler only supports single input.');
+    }
+
+    const input = sources[Object.keys(sources)[0]];
+    const output = compile.compileJson(input, optimize);
+    return translateOutput(output, libraries);
+  }
+
+  return formatFatalError('Compiler does not support any known interface.');
+}
+
+function isOptimizerEnabled (input) {
+  return input.settings && input.settings.optimizer && input.settings.optimizer.enabled;
+}
+
+function translateSources (input) {
+  const sources = {};
+
+  for (const source in input.sources) {
+    if (input.sources[source].content !== null) {
+      sources[source] = input.sources[source].content;
+    } else {
+      // force failure
+      return null;
+    }
+  }
+
+  return sources;
+}
+
+function librariesSupplied (input) {
+  if (!isNil(input.settings)) return input.settings.libraries;
+}
+
+function translateOutput (outputRaw, libraries) {
+  let parsedOutput;
+
+  try {
+    parsedOutput = JSON.parse(outputRaw);
+  } catch (e) {
+    return formatFatalError(`Compiler returned invalid JSON: ${e.message}`);
+  }
+
+  const output = translate.translateJsonCompilerOutput(parsedOutput, libraries);
+
+  if (isNil(output)) {
+    return formatFatalError('Failed to process output.');
+  }
+
+  return JSON.stringify(output);
+}
+
+export = wrapper;


### PR DESCRIPTION
# Why? 

This change works on refactoring out the wrapper.ts file to allow improved maintainability, extensibility with support of easy typing. The current implementation is one continuous function call which allocates all the bindings with hard to follow scoping.

Any bindings of methods have been split out into the `binding` directly, currently containing the core (anything not compiler related) and compiler related bound functions.

# Whats Next? 

Since the wrapper is the main entry point for most consumers of the service, this should allow cleanly defined types to be exported with the package. Allowing language servers and IDEs to consume the types and expose them to the user for an improved experience. 

* The callback implementation to apply changes based on some additional input arguments can now be tackled as it can be harder to follow. I was going to do it in this PR but it was outside of the scope. 

This has been done here #615 