### PR TITLE
Fix solc-js injection in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,20 +83,34 @@ commands:
       tarball-path:
         type: string
         default: solc-js.tgz
-      install-command:
-        type: string
-        default: npm install
+      package-manager:
+        type: enum
+        enum: ["npm", "yarn"]
+        default: npm
     steps:
+      - run:
+          name: "Sanity check: tarball exists and the target dir contains a JS project"
+          command: |
+            [[ -f "<<parameters.tarball-path>>" ]]
+            [[ -f "<<parameters.path>>/package.json" ]]
       - run:
           name: Inject solc-js from the tarball into dependencies at <<parameters.path>>
           command: |
-            [[ -f "<<parameters.tarball-path>>" ]]
             absolute_tarball_path=$(realpath "<<parameters.tarball-path>>")
-            for solc_module in $(find "<<parameters.path>>" -type d -path "*/node_modules/solc"); do
-                pushd "${solc_module}/../.."
-                <<parameters.install-command>> "$absolute_tarball_path" --ignore-workspace-root-check
-                popd
-            done
+            cd "<<parameters.path>>"
+            mv package.json original-package.json
+            # NOTE: The 'overrides' feature requires npm >= 8.3. Yarn requires `resolutions` instead.
+            jq ". + {overrides: {solc: \"${absolute_tarball_path}\"}} + {resolutions: {solc: \"${absolute_tarball_path}\"}}" original-package.json > package.json
+            "<<parameters.package-manager>>" install
+      - run:
+          name: "Sanity check: all transitive dependencies successfully replaced with the tarball"
+          command: |
+            solc_version=$(jq --raw-output .version solc-js/package.json)
+            cd "<<parameters.path>>"
+            if "<<parameters.package-manager>>" list --pattern solc | grep 'solc@' | grep -v "solc@${solc_version}"; then
+              echo "Another version of solc-js is still present in the dependency tree."
+              exit 1
+            fi
 
   provision-and-package-solcjs:
     description: "Creates a package out of latest solc-js to test its installation as a dependency."
@@ -124,7 +138,7 @@ commands:
           dependency-file: yarn.lock
       - inject-solc-js-tarball:
           path: hardhat/
-          install-command: yarn add
+          package-manager: yarn
 
   provision-truffle-with-packaged-solcjs:
     description: "Clones Truffle repository and configures it to use a local clone of solc-js."
@@ -132,18 +146,8 @@ commands:
       - run: git clone --depth 1 "https://github.com/trufflesuite/truffle" truffle/
       - install-truffle-dependencies
       - inject-solc-js-tarball:
-          path: truffle/node_modules/
-          install-command: yarn add
-      - run:
-          name: Neutralize any copies of solc-js outside of node_modules/
-          command: |
-            # NOTE: Injecting solc-js into node_modules/ dirs located under truffle/packages/ causes
-            # an error 'Tarball is not in network and can not be located in cache'. These are not
-            # supposed to be used but let's remove them just in case.
-            find truffle/ \
-              -path "*/solc/wrapper.js" \
-              -not -path "truffle/node_modules/*" \
-              -printf "%h\n" | xargs --verbose rm -r
+          path: truffle/
+          package-manager: yarn
 
 jobs:
   node-base: &node-base
@@ -185,7 +189,18 @@ jobs:
       - provision-and-package-solcjs
       - provision-hardhat-with-packaged-solcjs
       - run:
-          name: Run hardhat-core test suite with its default solc
+          name: Restore the default solc binary expected by Hardhat
+          command: |
+            # Hardhat downloader tests are hard-coded to expect the version that comes with the solc-js.
+            # We forced latest solc-js but we still want the default binary with it.
+            hardhat_default_solc_version=$(jq --raw-output '.dependencies.solc' hardhat/packages/hardhat-core/package.json)
+            mkdir hardhat-default-solc/
+            pushd hardhat-default-solc/
+            npm install "solc@${hardhat_default_solc_version}"
+            popd
+            ln -sf ../../../hardhat-default-solc/node_modules/solc/soljson.js hardhat/node_modules/solc/soljson.js
+      - run:
+          name: Run hardhat-core test suite with its default solc binary
           command: |
             cd hardhat/packages/hardhat-core
             # TODO: yarn build should not be needed to run these tests. Remove it.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ workflows:
       - hardhat-core-latest-solc
       - hardhat-sample-project
       - truffle-sample-project
+      - cli-smoke-test
 
 version: 2.1
 
@@ -310,6 +311,35 @@ jobs:
             ! [[ -e build/ ]] || false
             echo "module.exports['compilers'] = {solc: {version: '$(realpath node_modules/solc/)'}}" > truffle-config.js
             node ../truffle/node_modules/.bin/truffle test
+
+  cli-smoke-test:
+    docker:
+      - image: circleci/node:17
+    steps:
+      - update-npm
+      - show-npm-version
+      - provision-and-package-solcjs
+      - run:
+          name: "CLI smoke test (repository)"
+          command: |
+            cd solc-js
+            dist/solc.js --version
+
+            echo "contract C {}" > C.sol
+            dist/solc.js C.sol --bin
+            [[ -f C_sol_C.bin ]]
+      - run:
+          name: "CLI smoke test (package)"
+          command: |
+            mkdir package/
+            cd package/
+            npm install ../solc-js.tgz
+
+            npx solcjs --version
+
+            echo "contract C {}" > C.sol
+            npx solcjs C.sol --bin
+            [[ -f C_sol_C.bin ]]
 
   node-v10:
     <<: *node-base

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,13 @@ commands:
           name: Versions
           command: npm version
 
+  update-npm:
+    steps:
+      - run:
+          name: Update globally available npm to the latest version
+          # Note: We need npm >= 8.3 which supports 'overrides' in package.json
+          command: sudo npm install npm --global
+
   install-dependencies:
     parameters:
       cache-id:
@@ -148,6 +155,7 @@ jobs:
         type: boolean
         default: false
     steps:
+      # We want the default npm here. Older one might not work with older node.js
       - show-npm-version
       - checkout
       - install-dependencies:
@@ -172,6 +180,7 @@ jobs:
     docker:
       - image: circleci/node:16
     steps:
+      - update-npm
       - show-npm-version
       - provision-and-package-solcjs
       - provision-hardhat-with-packaged-solcjs
@@ -188,6 +197,7 @@ jobs:
     docker:
       - image: circleci/node:16
     steps:
+      - update-npm
       - show-npm-version
       - provision-and-package-solcjs
       - provision-hardhat-with-packaged-solcjs
@@ -205,6 +215,7 @@ jobs:
     docker:
       - image: circleci/node:16
     steps:
+      - update-npm
       - show-npm-version
       - provision-and-package-solcjs
       - run: git clone --depth 1 "https://github.com/nomiclabs/hardhat-hackathon-boilerplate" boilerplate/
@@ -258,6 +269,7 @@ jobs:
     docker:
       - image: circleci/node:12
     steps:
+      - update-npm
       - show-npm-version
       - provision-and-package-solcjs
       - provision-truffle-with-packaged-solcjs


### PR DESCRIPTION
~Depends on #623.~ Merged.

This PR changes the mechanism for injecting solc-js as a dependency of Truffle and Hardhat, introduced in #594, to make it more robust.

Normally when you install a boilerplate project you get multiple copies of `solc` in the dependency tree and looks like the method I used did not actually replace all of them. The way it was done is generally very hacky - going to the dependency dir and using npm or yarn to install a new version of the dependency. It works most of the time but sometimes also changes the dependency tree in weird ways and, honestly, I don't 100% understand what npm/yarn is exactly doing. Their dependency trees are just too complex.

Now I switched to the `overrides` feature, newly added in npm 8.3. This should be more reliable. yarn has a similar feature but the key is named differently ([`resolutions`](https://classic.yarnpkg.com/lang/en/docs/selective-version-resolutions/)) so to make things simpler, I'm just always using npm.

 I'm also adding a sanity check to make sure that there are no other versions of `solc` in the dependency tree.

When we ensure that tests do break here, I can rebase it on #623 to make sure it actually fixes the problem.