### PR TITLE
Fix CLI `--version` test to use version from the binary not `package.json`

### DIFF
--- a/test/cli.ts
+++ b/test/cli.ts
@@ -1,12 +1,13 @@
 import tape from 'tape';
 import spawn from 'tape-spawn';
 import * as path from 'path';
-const pkg = require('../package.json');
+import solc from '../';
 
 tape('CLI', function (t) {
   t.test('--version', function (st) {
     const spt = spawn(st, './solc.js --version');
-    spt.stdout.match(RegExp(pkg.version + '(-[^a-zA-A0-9.+]+)?(\\+[^a-zA-Z0-9.-]+)?'));
+    spt.stdout.match(solc.version() + '\n');
+    spt.stdout.match(/^\s*[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?\+commit\.[0-9a-f]+([a-zA-Z0-9.-]+)?\s*$/);
     spt.stderr.empty();
     spt.end();
   });


### PR DESCRIPTION
Currently tests in `cli.ts` are hard-coded to require a binary with version matching `package.json`. This not true in general and causes problems in #598.

This PR changes the test to only require the output from `--version` to match the output of `version()` function in the binary. I also kept a modified version of the previous check as a sanity check - to match that the output actually looks like our version string.