### PR TITLE
Adding command to copy meta files into dist dir

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "postbuild": "node build/postbuild.js",
+    "postbuild": "node build/postbuild.js && cp README.md LICENSE dist/",
     "lint": "eslint --ext .js,.ts .",
     "lint:fix": "eslint --fix --ext .js,.ts .",
     "updateBinary": "node build/clean.js && ts-node ./downloadCurrentVersion.ts && ts-node ./verifyVersion.ts",


### PR DESCRIPTION
Fixes #635.
Closes #647.

Adding the LICENSE and README.md files back to tarball.

Output from the `npm run build:tarball` command:
<img width="298" alt="Screenshot 2022-07-07 at 11 29 55 PM" src="https://user-images.githubusercontent.com/26125827/177930657-aea6f646-6990-4213-bad7-2831c4728f95.png">
