### PR TITLE
Run Truffle on newer node.js in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,7 +284,7 @@ jobs:
 
   truffle-sample-project:
     docker:
-      - image: circleci/node:12
+      - image: circleci/node:16
     steps:
       - update-npm
       - show-npm-version


### PR DESCRIPTION
It used to require 12 and would file with a newer one. Apparently now it requires 14 or later.