### PR TITLE
Changed Error in cli.ts from SyntaxError to just Error

### DIFF
--- a/test/cli.ts
+++ b/test/cli.ts
@@ -59,7 +59,7 @@ tape('CLI', function (t) {
 
   t.test('incorrect source source', function (st) {
     const spt = spawn(st, './solc.js --bin test/resources/fixtureIncorrectSource.sol');
-    spt.stderr.match(/SyntaxError: Invalid pragma "contract"/);
+    spt.stderr.match(/Error: Invalid pragma "contract"/);
     spt.end();
   });
 


### PR DESCRIPTION
This change is in line with the change in solidity repo. Error with type information are replaced with severity values. So, only the word Error appears

Made to fix CI errors appearing in https://github.com/ethereum/solidity/pull/13162