### PR TITLE
Add CI job to check if updateBinary downloads the correct release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,7 @@ workflows:
       - truffle-sample-project
       - cli-smoke-test
       - solidity-solcjs-ext-test
+      - download-release-solc-test
 
 version: 2.1
 
@@ -352,6 +353,16 @@ jobs:
       - run: git clone --depth 1 "https://github.com/ethereum/solidity" solidity/
       - run: cd solidity/ && curl "https://binaries.soliditylang.org/bin/soljson-nightly.js" --location --output soljson.js
       - run: cd solidity/ && test/externalTests/solc-js/solc-js.sh "$(realpath soljson.js)" "$(scripts/get_version.sh)" "$(realpath ../solc-js/)"
+
+  download-release-solc-test:
+    docker:
+      - image: cimg/node:16.15
+    steps:
+      - show-npm-version
+      - provision-and-package-solcjs
+      - run:
+          name: Check solc version with the released version
+          command: cd solc-js && scripts/update-and-check-binary.sh
 
   node-v10:
     <<: *node-base

--- a/scripts/update-and-check-binary.sh
+++ b/scripts/update-and-check-binary.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+BASE_URL="https://binaries.soliditylang.org/bin"
+REPO_ROOT="$(dirname "$0")/.."
+
+function fail() {
+	echo -e "$@" >&2
+	exit 1
+}
+
+function check_version() {
+	current_version=$(node ./dist/solc.js --version | sed -En 's/^(.*).Emscripten.*/\1/p')
+
+	# Retrieve the correspondent released version
+	short_version=$(echo "${current_version}" | sed -En 's/^([0-9.]+).*\+commit\.[0-9a-f]+.*$/\1/p')
+	release_version=$(curl -s "${BASE_URL}/list.json"  | jq ".releases | .[\"${short_version}\"]" | tr -d '"' | sed -En 's/^soljson-v(.*).js$/\1/p')
+
+	# check if current version exists as release
+	if [ "${current_version}" != "${release_version}" ]; then
+		fail "Failed: version mismatch:\n [current]: ${current_version}\n [release]: ${release_version}"
+	fi
+
+	current_sha=$(shasum -b -a 256 ./soljson.js | awk '{ print $1 }')
+	release_sha=$(curl -s "${BASE_URL}/list.json" | jq ".builds[] | select(.longVersion == \"${release_version}\") | .sha256" | tr -d '"' | sed 's/^0x//')
+
+	# check if sha matches
+	if [ "${current_sha}" != "${release_sha}" ]; then
+		fail "Failed: checksum mismatch:\n [current]: ${current_sha}\n [release]: ${release_sha}"
+	fi
+}
+
+(
+	cd "${REPO_ROOT}"
+
+	# Remove previous soljson.js binary if exists
+	[[ -f soljson.js ]] && rm -f soljson.js
+
+	# Update soljson.js binary
+	npm run updateBinary
+	npm run build
+
+	# Check if current binary works
+	echo "contract C {}" > C.sol
+	node ./dist/solc.js C.sol --bin
+	[[ ! -f C_sol_C.bin ]] && fail "Failed: downloaded binary is not working"
+	rm -f C.sol C_sol_C.bin
+
+	check_version
+)

--- a/scripts/update-and-check-binary.sh
+++ b/scripts/update-and-check-binary.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 BASE_URL="https://binaries.soliditylang.org/bin"
 REPO_ROOT="$(dirname "$0")/.."
 
@@ -39,11 +41,11 @@ function check_version() {
 	npm run updateBinary
 	npm run build
 
+	check_version
+
 	# Check if current binary works
 	echo "contract C {}" > C.sol
 	node ./dist/solc.js C.sol --bin
-	[[ ! -f C_sol_C.bin ]] && fail "Failed: downloaded binary is not working"
+	[[ ! -f C_sol_C.bin ]] && fail "Failed: downloaded binary may not be working properly"
 	rm -f C.sol C_sol_C.bin
-
-	check_version
 )


### PR DESCRIPTION
This PR addresses the comments made here https://github.com/ethereum/solc-js/pull/648#issuecomment-1218209344 and is part of the solution for the issue https://github.com/ethereum/solc-js/issues/632.
It adds a CI job to test if the current version is equal to the downloaded release when using the `updateBinary` command.