### PR TITLE
Add CI job to check coding style

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ workflows:
   version: 2.1
   node-multi-build:
     jobs:
+      - check-coding-style
       - node-v10
       - node-v12
       - node-v14
@@ -16,6 +17,9 @@ workflows:
       - solidity-solcjs-ext-test
 
 version: 2.1
+
+orbs:
+  shellcheck: circleci/shellcheck@volatile
 
 commands:
   show-npm-version:
@@ -181,6 +185,24 @@ jobs:
             - run:
                 name: coveralls
                 command: npm run coveralls
+
+  check-coding-style:
+    docker:
+      - image: cimg/node:current
+    steps:
+      - show-npm-version
+      - checkout
+      - shellcheck/install
+      - install-dependencies:
+          cache-id: solc-js
+      - run:
+          name: Check for javascript/typescript coding style
+          command: npm run lint
+      - shellcheck/check:
+          ignore-dirs: |
+            ./.git
+            ./node_modules
+            ./dist
 
   hardhat-core-default-solc:
     # Runs out of memory on 'medium'.


### PR DESCRIPTION
This PR adds a CI job to perform coding style checks as suggested here: https://github.com/ethereum/solc-js/pull/659#discussion_r978652925

It performs the `eslint` checks for `.js` and `.ts` files using the npm lint script and checks the `.sh` files using the [shellcheck circleCI orb](https://circleci.com/developer/orbs/orb/circleci/shellcheck).