### PR TITLE
Bump node versions in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,8 @@ workflows:
       - node-v14
       - node-v16
       - node-v18
-      - node-v20:
+      - node-v20
+      - node-current:
           run_coveralls: true
       - hardhat-core-default-solc
       - hardhat-core-latest-solc
@@ -397,3 +398,7 @@ jobs:
     <<: *node-base
     docker:
       - image: cimg/node:20.5
+  node-current:
+    <<: *node-base
+    docker:
+      - image: cimg/node:current

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,8 +6,7 @@ workflows:
       - node-v10
       - node-v12
       - node-v14
-      - node-v16:
-          run_coveralls: true
+      - node-v16
       - node-v18
       - node-v20:
           run_coveralls: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,9 +173,6 @@ jobs:
       - install-dependencies:
           cache-id: solc-js
       - run:
-          name: install-npm
-          command: npm install
-      - run:
           name: updateBinary
           command: npm run updateBinary
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -207,7 +207,7 @@ jobs:
     # Runs out of memory on 'medium'.
     resource_class: medium+
     docker:
-      - image: cimg/node:16.15
+      - image: cimg/node:current
     steps:
       - show-npm-version
       - provision-and-package-solcjs
@@ -234,7 +234,7 @@ jobs:
 
   hardhat-core-latest-solc:
     docker:
-      - image: cimg/node:16.15
+      - image: cimg/node:current
     steps:
       - show-npm-version
       - provision-and-package-solcjs
@@ -251,7 +251,7 @@ jobs:
 
   hardhat-sample-project:
     docker:
-      - image: cimg/node:16.15
+      - image: cimg/node:current
     steps:
       - show-npm-version
       - provision-and-package-solcjs
@@ -304,7 +304,7 @@ jobs:
 
   truffle-sample-project:
     docker:
-      - image: cimg/node:20.5
+      - image: cimg/node:lts
     steps:
       - update-npm
       - show-npm-version
@@ -385,19 +385,19 @@ jobs:
   node-v14:
     <<: *node-base
     docker:
-      - image: cimg/node:14.19
+      - image: cimg/node:14.21
   node-v16:
     <<: *node-base
     docker:
-      - image: cimg/node:16.15
+      - image: cimg/node:16.20
   node-v18:
     <<: *node-base
     docker:
-      - image: cimg/node:18.3
+      - image: cimg/node:18.18
   node-v20:
     <<: *node-base
     docker:
-      - image: cimg/node:20.5
+      - image: cimg/node:20.9
   node-current:
     <<: *node-base
     docker:


### PR DESCRIPTION
This bumps all minor versions to latest, and also adds a new run on `node:current` (which is node 21).

It also bumps node version in Hardhat jobs that were not on `current` only because at the time of node 17 Hardhat did not work with it.

Truffle does not work with node 21, but is fine with node 20, which is the current `lts`.