### PR TITLE
Add a nightly CI run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ defaults:
 
 workflows:
   version: 2.1
-  node-multi-build:
+  pr-checks:
     jobs:
       - check-coding-style
       - node-v10
@@ -16,6 +16,24 @@ workflows:
       - node-v20
       - node-current:
           run_coveralls: true
+      - build-package
+      - hardhat-core-default-solc: *requires_package
+      - hardhat-core-latest-solc: *requires_package
+      - hardhat-sample-project: *requires_package
+      - cli-smoke-test: *requires_package
+      - solidity-solcjs-ext-test
+
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
+
+    jobs:
+      - node-current
       - build-package
       - hardhat-core-default-solc: *requires_package
       - hardhat-core-latest-solc: *requires_package


### PR DESCRIPTION
We should really have a nightly run in this repo because there's not that much traffic here and we sometimes miss CI being broken. With a nightly run we won't have to remember to run CI manually and we'll actually notice breakage as it happens, not just before a release.

It would be useful to also have notifications for the Matrix CI channel. And a run with a nightly binary from solc-bin, which would have detected breakage like #732 and, combined with that notification, would let us know when nightlies in solc-bin are broken (https://github.com/ethereum/solidity/issues/13507). I did not do any of those things though. This is just a simple nightly workflow build quickly out of what I already had at hand.