### PR TITLE
Docs improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ The low-level API is as follows:
 - `solc.lowlevel.compileCallback`: this supports callbacks, introduced in 0.2.1
 - `solc.lowlevel.compileStandard`: this works just like `compile` above, but is only present in compilers after (and including) 0.4.11
 
-For examples how to use them, please refer to the README of the above mentioned solc-js releases.
+For examples of how to use them, please refer to the README of the above-mentioned solc-js releases.
 
 **Note**: These low-level functions remain available for compatibility reasons.
 However, they were superseded by the `compile()` function and are no longer required.

--- a/bindings/core.ts
+++ b/bindings/core.ts
@@ -128,7 +128,7 @@ function bindReset (solJson) {
  *
  * @param solJson The Emscripten compiled Solidity object.
  * @param alloc The memory allocation function.
- * @param str The source string being copied to a C string.
+ * @param str The source string is being copied to a C string.
  * @param ptr The pointer location where the C string will be set.
  */
 function unboundCopyToCString (solJson, alloc, str, ptr) {

--- a/common/types.ts
+++ b/common/types.ts
@@ -1,7 +1,7 @@
 /**
  * A mapping between libraries and the addresses to which they were deployed.
  *
- * Containing support for two level configuration, These two level
+ * Containing support for two-level configuration, this two-level
  * configurations can be seen below.
  *
  * {
@@ -16,7 +16,7 @@ export interface LibraryAddresses {
 
 /**
  * A mapping between libraries and lists of placeholder instances present in their hex-encoded bytecode.
- * For each placeholder its length and the position of the first character is stored.
+ * For each placeholder its length and the position of the first character are stored.
  *
  * Each start and length entry will always directly refer to the position in
  * binary and not hex-encoded bytecode.

--- a/test/smtchecker.ts
+++ b/test/smtchecker.ts
@@ -56,7 +56,7 @@ tape('SMTChecker', function (t) {
 
 tape('SMTCheckerWithSolver', function (t) {
   // In these tests we require z3 to actually run the solver.
-  // This uses the SMT double run mechanism instead of the callback.
+  // This uses the SMT double-run mechanism instead of the callback.
 
   t.test('Simple test with axuiliaryInputRequested', function (st) {
     const z3 = smtsolver.availableSolvers.filter(solver => solver.command === 'z3');


### PR DESCRIPTION
Rectify typographical inaccuracies

This PR addresses several typographical errors across various files in the project. The changes improve readability and maintain the professional standard of the documentation and code comments.

Justification
Typographical errors, while minor, can detract from the overall quality of the project. Correcting these errors ensures clarity and professionalism, making the project more accessible and understandable for current and future contributors.