### PR TITLE
Use cimg/node instead of deprecated circleci/node

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -421,7 +421,7 @@ jobs:
 
   solidity-solcjs-ext-test:
     docker:
-      - image: circleci/node
+      - image: cimg/node:current
     steps:
       - show-npm-version
       - checkout:


### PR DESCRIPTION
During the 0.8.27 release I noticed that we missed to upgrade the image used by `solidity-solcjs-ext-test` in our CI config.

This PR upgrades such CircleCI convenience image to fix the following warning: https://app.circleci.com/pipelines/github/ethereum/solc-js/1670/workflows/34f69e77-0e63-491e-8d41-d0c62663c700/jobs/10461

More info about the deprecation here: https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034