### PR TITLE
Fix typo in code example Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ var outputABI = abi.update('0.3.6', inputABI);
 There is a helper available to format old JSON assembly output into a text familiar to earlier users of Remix IDE.
 
 ```
-var translate = require('solc/translate')
+var translate = require('solc/translate');
 
 // assemblyJSON refers to the JSON of the given assembly and sourceCode is the source of which the assembly was generated from
 var output = translate.prettyPrintLegacyAssemblyJSON(assemblyJSON, sourceCode)


### PR DESCRIPTION
**Description:**  
This pull request addresses a minor but important issue in the code example provided in the **"Formatting old JSON assembly output"** section.  

<img width="877" alt="Снимок экрана 2024-11-21 в 12 41 05" src="https://github.com/user-attachments/assets/9f31cd4f-b05e-4af9-9109-6d70f545bdad">

### Issue:  
The following line in the documentation has a missing semicolon at the end:  
```javascript  
var translate = require('solc/translate')  
```  
### Fix:  
The corrected version adds the missing semicolon to align with JavaScript coding standards:  
```javascript  
var translate = require('solc/translate');  
```  

### Importance:  
While this is a small typo, maintaining proper syntax in code examples is critical for:  
1. **Readability:** Adhering to standard coding practices makes the code easier to understand for readers.  
2. **Compatibility:** Ensuring proper syntax prevents potential issues when the code is copied into stricter environments or linted using standard tools.  

**Thank you for reviewing this PR. I believe this fix contributes to maintaining high-quality documentation and a professional standard for users.**