### PR TITLE
Drop nodejs 10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,6 @@ workflows:
   pr-checks:
     jobs:
       - check-coding-style
-      - node-v10
       - node-v12
       - node-v14
       - node-v16
@@ -345,10 +344,6 @@ jobs:
       - run: cd solidity/ && curl "https://binaries.soliditylang.org/bin/soljson-nightly.js" --location --output soljson.js
       - run: cd solidity/ && test/externalTests/solc-js/solc-js.sh "$(realpath soljson.js)" "$(scripts/get_version.sh)" "$(realpath ../solc-js/)"
 
-  node-v10:
-    <<: *node-base
-    docker:
-      - image: cimg/node:10.24
   node-v12:
     <<: *node-base
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ workflows:
       - node-v16
       - node-v18
       - node-v20
+      - node-v22
       - node-current:
           run_coveralls: true
       - build-package
@@ -364,6 +365,10 @@ jobs:
     <<: *node-base
     docker:
       - image: cimg/node:20.9
+  node-v22:
+    <<: *node-base
+    docker:
+      - image: cimg/node:22.14
   node-current:
     <<: *node-base
     docker:

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "compiler"
   ],
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "files": [
     "common/*.js",


### PR DESCRIPTION
This PR removes Node.js 10 from our CI as it started failing due to many dependencies increasing their Node.js version requirements. See: https://app.circleci.com/pipelines/github/ethereum/solc-js/1775/workflows/14eb5b72-7624-47e5-a302-a407c1fd4f58/jobs/11376/parallel-runs/0?invite=true#step-105-0_136 and this error: https://app.circleci.com/pipelines/github/ethereum/solc-js/1775/workflows/14eb5b72-7624-47e5-a302-a407c1fd4f58/jobs/11376?invite=true#step-108-209_118, which is because `Object.fromEntries` is only available in Node.js 12+. We could potentially workaround the issue using `DISABLE_V8_COMPILE_CACHE=1`, but I believe that it makes more sense to update the packages.

Also, ESLint v8 dropped support for Node.js 10, as noted here https://github.com/eslint/eslint/issues/15560#issuecomment-1055090605.

As a result, we should probably consider bumping everything to align with the newer Node.js versions. And we might need to revisit the suggestion from https://github.com/ethereum/solc-js/pull/723 to lock our dependencies for better consistency.

Note, I decided to bump some versions, but not the major ones yet.