### PR TITLE
chore: fix typos

### DIFF
--- a/bindings/helpers.ts
+++ b/bindings/helpers.ts
@@ -26,7 +26,7 @@ export function getSupportedMethods (solJson) {
     resetSupported: anyMethodExists(solJson, 'solidity_reset'),
     compileJsonSupported: anyMethodExists(solJson, 'compileJSON'),
     compileJsonMultiSupported: anyMethodExists(solJson, 'compileJSONMulti'),
-    compileJsonCallbackSuppported: anyMethodExists(solJson, 'compileJSONCallback'),
+    compileJsonCallbackSupported: anyMethodExists(solJson, 'compileJSONCallback'),
     compileJsonStandardSupported: anyMethodExists(solJson, 'compileStandard', 'solidity_compile')
   };
 }

--- a/wrapper.ts
+++ b/wrapper.ts
@@ -28,7 +28,7 @@ function wrapper (soljson) {
     features: {
       legacySingleInput: methodFlags.compileJsonStandardSupported,
       multipleInputs: methodFlags.compileJsonMultiSupported || methodFlags.compileJsonStandardSupported,
-      importCallback: methodFlags.compileJsonCallbackSuppported || methodFlags.compileJsonStandardSupported,
+      importCallback: methodFlags.compileJsonCallbackSupported || methodFlags.compileJsonStandardSupported,
       nativeStandardJSON: methodFlags.compileJsonStandardSupported
     },
     compile: compileStandardWrapper.bind(this, compileBindings),


### PR DESCRIPTION
This PR corrects the naming inconsistency in the JSON compilation callback method:
- Fixed the typo in compileJsonCallbackSuppported to compileJsonCallbackSupported in bindings/helpers.ts
- Updated the corresponding reference in wrapper.ts
These changes ensure consistent naming throughout the codebase and improve code maintainability.