### PR TITLE
Update tmp package version to 0.2.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "js-sha3": "0.8.0",
     "memorystream": "^0.3.1",
     "semver": "^5.5.0",
-    "tmp": "0.0.33"
+    "tmp": "0.2.6"
   },
   "devDependencies": {
     "@types/node": "^16.11.7",


### PR DESCRIPTION
## Summary

Bump `tmp` to `0.2.6` to fix a high severity security vulnerability.

## Background

`tmp@<=0.2.5` is affected by a path traversal vulnerability: [GHSA-ph9p-34f9-6g65](https://github.com/advisories/GHSA-ph9p-34f9-6g65).

## Changes

- Upgrade `tmp` to `0.2.6`

## Validation

- Dependency updated
- CI / tests should verify compatibility