### PR TITLE
Ignore BMC deprecation warning

### DIFF
--- a/test/smtcallback.ts
+++ b/test/smtcallback.ts
@@ -20,6 +20,11 @@ function collectErrors (solOutput) {
     if (error.message.includes('This is a pre-release compiler version')) {
       continue;
     }
+    // BMC engine deprecation notice.
+    // TODO: Remove when next solc breaking release drops support.
+    if (error.errorCode === '3993') {
+      continue;
+    }
     errors.push(error.message);
   }
   return errors;


### PR DESCRIPTION
solc is deprecating the use of BMC engine by the SMTChecker (https://github.com/argotorg/solidity/pull/16877) and the related warning breaks the tests.
This ignores the warning while BMC is not completely dropped.